### PR TITLE
feat: UI 리디자인 - 다크 테마 및 글래스모피즘 스타일 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1608,6 +1609,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1617,6 +1619,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.6.tgz",
       "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1689,6 +1692,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -1947,6 +1951,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2154,6 +2159,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2720,6 +2726,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4472,6 +4479,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -4677,6 +4685,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4686,6 +4695,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4698,6 +4708,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
       "integrity": "sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4748,6 +4759,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4871,7 +4883,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5306,6 +5319,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5385,6 +5399,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5624,6 +5639,7 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5717,6 +5733,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5817,6 +5834,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,32 +3,9 @@
  * 
  * 파일 용도:
  * 마법사 페이지의 공통 레이아웃 컴포넌트
+ * - 다크 테마 + 글래스모피즘 스타일
  * - 헤더, 사이드바, 메인 콘텐츠 영역 제공
  * - 마법사 진행 상태 표시
- * - 단계별 네비게이션 UI
- * 
- * 호출 구조:
- * Layout (이 컴포넌트)
- *   ├─> useWizardStore - 마법사 진행 상태
- *   │   ├─> currentStep - 현재 단계
- *   │   ├─> steps - 전체 단계 목록
- *   │   └─> isStepCompleted() - 단계 완료 여부
- *   │
- *   ├─> useProjectStore - 프로젝트 정보
- *   │   └─> currentProject - 현재 프로젝트
- *   │
- *   └─> 자식 컴포넌트
- *       ├─> SaveIndicator - 저장 상태 표시
- *       ├─> Progress - 진행률 바
- *       └─> Outlet - 라우트 콘텐츠 (WizardStep, BusinessPlanViewer)
- * 
- * 데이터 흐름:
- * useWizardStore → 진행률 계산 → Progress 컴포넌트
- * useWizardStore → 단계 목록 → 사이드바 네비게이션
- * 
- * 조건부 렌더링:
- * - /wizard/* 경로: 전체 레이아웃 (헤더 + 사이드바 + 콘텐츠)
- * - 기타 경로: Outlet만 렌더링 (레이아웃 없음)
  */
 
 import React from 'react';
@@ -37,29 +14,12 @@ import { useWizardStore } from '../stores/useWizardStore';
 import { useProjectStore } from '../stores/useProjectStore';
 import { SaveIndicator } from './SaveIndicator';
 import { Progress } from './ui';
-import { Check } from 'lucide-react';
+import { Check, Sparkles, ChevronRight } from 'lucide-react';
 import { cn } from '../lib/utils';
 
 /**
  * Layout 컴포넌트
- * 
- * 역할:
- * - 마법사 페이지의 공통 레이아웃 제공
- * - 헤더: 로고, 프로젝트명, 저장 상태
- * - 사이드바: 단계 목록, 진행률
- * - 메인: 각 단계의 콘텐츠 (Outlet)
- * 
- * 주요 기능:
- * 1. 진행률 계산 및 표시
- * 2. 단계별 네비게이션 (완료/진행 중/미완료 표시)
- * 3. 현재 단계 하이라이트
- * 4. 자동 저장 상태 표시
- * 
- * 조건부 렌더링:
- * - 마법사 페이지(/wizard/*)일 때만 레이아웃 표시
- * - 그 외 페이지는 Outlet만 렌더링
- * 
- * @returns {JSX.Element} 레이아웃 컴포넌트
+ * 다크 테마 마법사 레이아웃
  */
 export const Layout: React.FC = () => {
   const location = useLocation();
@@ -78,42 +38,61 @@ export const Layout: React.FC = () => {
   const progressPercentage = (completedSteps / steps.length) * 100;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen relative">
+      {/* 배경 효과 */}
+      <div className="fixed inset-0 bg-grid opacity-30 pointer-events-none" />
+      <div className="fixed top-0 left-0 w-96 h-96 bg-neon-500/10 rounded-full blur-3xl pointer-events-none" />
+      <div className="fixed bottom-0 right-0 w-80 h-80 bg-violet-500/10 rounded-full blur-3xl pointer-events-none" />
+
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
+      <header className="sticky top-0 z-50 backdrop-blur-xl bg-slate-950/80 border-b border-white/10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
+            {/* 로고 & 프로젝트명 */}
             <div className="flex items-center gap-4">
-              <Link to="/" className="text-xl font-bold text-primary-600">
-                StartupPlan
+              <Link 
+                to="/" 
+                className="flex items-center gap-2 group"
+              >
+                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-neon-400 to-neon-600 flex items-center justify-center shadow-neon transition-shadow group-hover:shadow-neon-lg">
+                  <Sparkles className="w-4 h-4 text-slate-900" />
+                </div>
+                <span className="text-lg font-display font-bold text-white">
+                  StartupPlan
+                </span>
               </Link>
+              
               {currentProject && (
                 <>
-                  <span className="text-gray-300">/</span>
-                  <span className="text-gray-700 font-medium">{currentProject.name}</span>
+                  <ChevronRight className="w-4 h-4 text-slate-600" />
+                  <span className="text-slate-300 font-medium truncate max-w-[200px]">
+                    {currentProject.name}
+                  </span>
                 </>
               )}
             </div>
+
+            {/* 저장 상태 */}
             <SaveIndicator />
           </div>
         </div>
       </header>
 
-      <div className="flex max-w-7xl mx-auto">
+      <div className="flex max-w-7xl mx-auto relative">
         {/* Sidebar */}
-        <aside className="w-64 bg-white border-r border-gray-200 min-h-[calc(100vh-4rem)] p-6">
-          <div className="mb-6">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-gray-700">진행률</span>
-              <span className="text-sm font-medium text-gray-900">
+        <aside className="w-72 sticky top-16 h-[calc(100vh-4rem)] p-6 overflow-y-auto">
+          <div className="glass-card p-5 mb-6">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-sm font-medium text-slate-400">진행률</span>
+              <span className="text-sm font-bold text-white">
                 {completedSteps}/{steps.length}
               </span>
             </div>
-            <Progress value={progressPercentage} showLabel />
+            <Progress value={progressPercentage} color="neon" />
           </div>
 
-          <nav className="space-y-1">
-            {steps.map((step) => {
+          <nav className="space-y-2">
+            {steps.map((step, index) => {
               const isCompleted = isStepCompleted(step.id);
               const isCurrent = currentStep === step.id;
 
@@ -122,37 +101,72 @@ export const Layout: React.FC = () => {
                   key={step.id}
                   to={`/wizard/${step.id}`}
                   className={cn(
-                    'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+                    'flex items-center gap-3 px-4 py-3 rounded-xl',
+                    'text-sm font-medium transition-all duration-300',
+                    'group',
                     isCurrent
-                      ? 'bg-primary-50 text-primary-700'
+                      ? 'bg-neon-500/20 text-neon-400 border border-neon-500/30'
                       : isCompleted
-                      ? 'text-gray-700 hover:bg-gray-50'
-                      : 'text-gray-400 hover:bg-gray-50'
+                      ? 'text-slate-300 hover:bg-white/5 hover:text-white'
+                      : 'text-slate-500 hover:bg-white/5 hover:text-slate-400'
                   )}
+                  style={{ animationDelay: `${index * 50}ms` }}
                 >
+                  {/* 단계 번호/체크 */}
                   <div className={cn(
-                    'flex items-center justify-center w-6 h-6 rounded-full text-xs flex-shrink-0',
+                    'flex items-center justify-center w-7 h-7 rounded-lg text-xs font-bold flex-shrink-0',
+                    'transition-all duration-300',
                     isCurrent
-                      ? 'bg-primary-600 text-white'
+                      ? 'bg-neon-500 text-slate-900 shadow-neon'
                       : isCompleted
-                      ? 'bg-green-500 text-white'
-                      : 'bg-gray-200 text-gray-500'
+                      ? 'bg-green-500/20 text-green-400 border border-green-500/30'
+                      : 'bg-white/5 text-slate-500 border border-white/10'
                   )}>
-                    {isCompleted ? <Check className="w-4 h-4" /> : step.id}
+                    {isCompleted ? (
+                      <Check className="w-4 h-4" />
+                    ) : (
+                      step.id
+                    )}
                   </div>
+
+                  {/* 단계 제목 */}
                   <span className="truncate">{step.title}</span>
+
+                  {/* 현재 단계 인디케이터 */}
+                  {isCurrent && (
+                    <div className="ml-auto w-1.5 h-1.5 rounded-full bg-neon-400 animate-pulse" />
+                  )}
                 </Link>
               );
             })}
           </nav>
+
+          {/* 빠른 링크 */}
+          <div className="mt-8 pt-6 border-t border-white/10">
+            <Link
+              to="/business-plan"
+              className={cn(
+                'flex items-center gap-3 px-4 py-3 rounded-xl',
+                'text-sm font-medium text-slate-500',
+                'hover:bg-white/5 hover:text-slate-300',
+                'transition-all duration-300'
+              )}
+            >
+              <div className="w-7 h-7 rounded-lg bg-violet-500/20 flex items-center justify-center">
+                <span className="text-violet-400 text-xs">📄</span>
+              </div>
+              <span>사업계획서 미리보기</span>
+            </Link>
+          </div>
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 p-8">
-          <Outlet />
+        <main className="flex-1 p-8 min-h-[calc(100vh-4rem)]">
+          <div className="animate-fade-in">
+            <Outlet />
+          </div>
         </main>
       </div>
     </div>
   );
 };
-

--- a/src/components/SaveIndicator.tsx
+++ b/src/components/SaveIndicator.tsx
@@ -3,44 +3,18 @@
  * 
  * 파일 용도:
  * 자동 저장 상태 표시 컴포넌트
+ * - 다크 테마 + 네온 스타일
  * - 저장 중, 저장 완료, 저장 실패 상태를 시각적으로 표시
- * - 헤더에 위치하여 사용자에게 저장 상태를 실시간 피드백
- * 
- * 호출 구조:
- * SaveIndicator (이 컴포넌트)
- *   └─> useProjectStore
- *       └─> saveStatus - 저장 상태 ('idle' | 'saving' | 'saved' | 'error')
- * 
- * 데이터 흐름:
- * useProjectStore.saveStatus → 상태에 따른 아이콘 및 텍스트 표시
- * 
- * 상태별 표시:
- * - idle: 표시 안 함
- * - saving: 구름 아이콘 + "저장 중..."
- * - saved: 체크 아이콘 + "저장됨"
- * - error: 경고 아이콘 + "저장 실패"
  */
 
 import React from 'react';
 import { useProjectStore } from '../stores/useProjectStore';
-import { Check, Cloud, AlertCircle } from 'lucide-react';
+import { Check, Cloud, AlertCircle, Loader2 } from 'lucide-react';
+import { cn } from '../lib/utils';
 
 /**
  * SaveIndicator 컴포넌트
- * 
- * 역할:
- * - 자동 저장 상태를 시각적으로 표시
- * - 사용자에게 데이터 손실 방지를 위한 피드백 제공
- * 
- * 표시 조건:
- * - saveStatus가 'idle'이 아닐 때만 표시
- * 
- * 상태별 스타일:
- * - saving: 회색 (진행 중)
- * - saved: 초록색 (성공)
- * - error: 빨간색 (실패)
- * 
- * @returns {JSX.Element | null} 저장 상태 표시 UI (idle일 경우 null)
+ * 자동 저장 상태를 시각적으로 표시
  */
 export const SaveIndicator: React.FC = () => {
   const { saveStatus } = useProjectStore();
@@ -51,19 +25,25 @@ export const SaveIndicator: React.FC = () => {
   // 상태별 표시 정보 매핑
   const indicators = {
     saving: {
-      icon: Cloud,
+      icon: Loader2,
       text: '저장 중...',
-      className: 'text-gray-600',
+      className: 'text-slate-400',
+      iconClass: 'animate-spin',
+      bgClass: 'bg-slate-500/10',
     },
     saved: {
       icon: Check,
       text: '저장됨',
-      className: 'text-green-600',
+      className: 'text-neon-400',
+      iconClass: '',
+      bgClass: 'bg-neon-500/10',
     },
     error: {
       icon: AlertCircle,
       text: '저장 실패',
-      className: 'text-red-600',
+      className: 'text-red-400',
+      iconClass: '',
+      bgClass: 'bg-red-500/10',
     },
   };
 
@@ -71,10 +51,14 @@ export const SaveIndicator: React.FC = () => {
   const Icon = indicator.icon;
 
   return (
-    <div className={`flex items-center gap-2 text-sm ${indicator.className}`}>
-      <Icon className="h-4 w-4" />
+    <div className={cn(
+      'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium',
+      'backdrop-blur-sm border border-white/10',
+      indicator.bgClass,
+      indicator.className
+    )}>
+      <Icon className={cn('h-4 w-4', indicator.iconClass)} />
       <span>{indicator.text}</span>
     </div>
   );
 };
-

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -2,15 +2,9 @@
  * 파일명: Badge.tsx
  * 
  * 파일 용도:
- * 재사용 가능한 배지(Badge) 컴포넌트
- * - 상태, 태그, 레이블 등을 표시하는 작은 UI 요소
- * - 5가지 variant 제공 (default, success, warning, danger, info)
- * - 작고 둥근 알약 형태
- * 
- * 사용 예시:
- * <Badge variant="success">완료</Badge>
- * <Badge variant="danger">긴급</Badge>
- * <Badge variant="info">새로운</Badge>
+ * 재사용 가능한 배지/태그 컴포넌트
+ * - 다양한 색상 옵션
+ * - 다크 테마 최적화
  */
 
 import React from 'react';
@@ -19,39 +13,35 @@ import { cn } from '../../lib/utils';
 interface BadgeProps {
   /** 배지 내용 */
   children: React.ReactNode;
-  /** 배지 스타일 변형 */
-  variant?: 'default' | 'success' | 'warning' | 'danger' | 'info';
+  /** 배지 색상 */
+  variant?: 'neon' | 'cyan' | 'violet' | 'slate' | 'success' | 'warning' | 'danger';
   /** 추가 CSS 클래스 */
   className?: string;
 }
 
 /**
  * Badge 컴포넌트
- * 
- * 역할:
- * - 상태, 카테고리, 태그 등을 시각적으로 표시
- * - 색상으로 의미 전달 (성공=초록, 경고=노랑, 위험=빨강 등)
- * 
- * @param {BadgeProps} props - 배지 속성
- * @returns {JSX.Element} 배지 엘리먼트
  */
-export const Badge: React.FC<BadgeProps> = ({ 
-  children, 
-  variant = 'default',
-  className 
+export const Badge: React.FC<BadgeProps> = ({
+  children,
+  variant = 'slate',
+  className
 }) => {
   const variants = {
-    default: 'bg-gray-100 text-gray-800',
-    success: 'bg-green-100 text-green-800',
-    warning: 'bg-yellow-100 text-yellow-800',
-    danger: 'bg-red-100 text-red-800',
-    info: 'bg-blue-100 text-blue-800',
+    neon: 'bg-neon-500/20 text-neon-400 border-neon-500/30',
+    cyan: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
+    violet: 'bg-violet-500/20 text-violet-400 border-violet-500/30',
+    slate: 'bg-slate-500/20 text-slate-400 border-slate-500/30',
+    success: 'bg-green-500/20 text-green-400 border-green-500/30',
+    warning: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
+    danger: 'bg-red-500/20 text-red-400 border-red-500/30',
   };
 
   return (
     <span
       className={cn(
         'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium',
+        'border backdrop-blur-sm',
         variants[variant],
         className
       )}
@@ -60,4 +50,3 @@ export const Badge: React.FC<BadgeProps> = ({
     </span>
   );
 };
-

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,15 +3,10 @@
  * 
  * 파일 용도:
  * 재사용 가능한 버튼 컴포넌트
- * - 다양한 스타일 variant 제공 (primary, secondary, outline, ghost, danger)
+ * - 다양한 스타일 variant 제공 (neon, secondary, outline, ghost, danger)
  * - 3가지 크기 옵션 (sm, md, lg)
  * - 로딩 상태 지원
- * - 표준 HTML 버튼 속성 모두 지원
- * 
- * 사용 예시:
- * <Button variant="primary" size="lg" isLoading={isSubmitting}>
- *   제출하기
- * </Button>
+ * - 다크 테마 + 네온 스타일
  */
 
 import React from 'react';
@@ -19,7 +14,7 @@ import { cn } from '../../lib/utils';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** 버튼 스타일 변형 */
-  variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';
+  variant?: 'neon' | 'secondary' | 'outline' | 'ghost' | 'danger';
   /** 버튼 크기 */
   size?: 'sm' | 'md' | 'lg';
   /** 로딩 상태 (스피너 표시 및 비활성화) */
@@ -30,17 +25,10 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 /**
  * Button 컴포넌트
- * 
- * 역할:
- * - 애플리케이션 전체에서 일관된 버튼 UI 제공
- * - 다양한 상황에 맞는 스타일과 크기 옵션
- * - 로딩/비활성화 상태 처리
- * 
- * @param {ButtonProps} props - 버튼 속성
- * @returns {JSX.Element} 버튼 엘리먼트
+ * 다크 테마에 최적화된 네온 스타일 버튼
  */
 export const Button: React.FC<ButtonProps> = ({
-  variant = 'primary',
+  variant = 'neon',
   size = 'md',
   isLoading = false,
   className,
@@ -48,20 +36,51 @@ export const Button: React.FC<ButtonProps> = ({
   disabled,
   ...props
 }) => {
-  const baseStyles = 'inline-flex items-center justify-center font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg';
+  const baseStyles = cn(
+    'inline-flex items-center justify-center font-semibold',
+    'transition-all duration-300 ease-out',
+    'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900',
+    'disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none',
+    'rounded-xl'
+  );
   
   const variants = {
-    primary: 'bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-500',
-    secondary: 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500',
-    outline: 'border-2 border-primary-600 text-primary-600 hover:bg-primary-50 focus:ring-primary-500',
-    ghost: 'text-gray-700 hover:bg-gray-100 focus:ring-gray-500',
-    danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+    neon: cn(
+      'bg-gradient-to-r from-neon-400 to-neon-500 text-slate-900',
+      'hover:from-neon-300 hover:to-neon-400',
+      'shadow-lg shadow-neon-500/25 hover:shadow-neon-500/40',
+      'hover:-translate-y-0.5',
+      'focus:ring-neon-500'
+    ),
+    secondary: cn(
+      'bg-slate-800 text-slate-100',
+      'hover:bg-slate-700',
+      'border border-slate-700 hover:border-slate-600',
+      'focus:ring-slate-500'
+    ),
+    outline: cn(
+      'bg-transparent text-neon-400',
+      'border-2 border-neon-500/50 hover:border-neon-400',
+      'hover:bg-neon-500/10',
+      'focus:ring-neon-500'
+    ),
+    ghost: cn(
+      'bg-transparent text-slate-300',
+      'hover:bg-white/10 hover:text-white',
+      'focus:ring-slate-500'
+    ),
+    danger: cn(
+      'bg-gradient-to-r from-red-500 to-red-600 text-white',
+      'hover:from-red-400 hover:to-red-500',
+      'shadow-lg shadow-red-500/25 hover:shadow-red-500/40',
+      'focus:ring-red-500'
+    ),
   };
   
   const sizes = {
-    sm: 'px-3 py-1.5 text-sm',
-    md: 'px-4 py-2 text-base',
-    lg: 'px-6 py-3 text-lg',
+    sm: 'px-4 py-2 text-sm',
+    md: 'px-5 py-2.5 text-base',
+    lg: 'px-8 py-3.5 text-lg',
   };
 
   return (
@@ -96,4 +115,3 @@ export const Button: React.FC<ButtonProps> = ({
     </button>
   );
 };
-

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -3,27 +3,9 @@
  * 
  * 파일 용도:
  * 재사용 가능한 카드 컴포넌트 및 관련 하위 컴포넌트
- * - Compound Component 패턴으로 구성
- * - 카드 구조: Card > CardHeader > CardTitle/CardDescription + CardContent + CardFooter
- * - 호버 효과 및 클릭 이벤트 지원
- * 
- * 컴포넌트 목록:
- * - Card: 메인 컨테이너
- * - CardHeader: 헤더 영역 (상단 구분선)
- * - CardTitle: 제목
- * - CardDescription: 설명
- * - CardContent: 본문
- * - CardFooter: 푸터 영역 (하단 구분선)
- * 
- * 사용 예시:
- * <Card hover onClick={handleClick}>
- *   <CardHeader>
- *     <CardTitle>제목</CardTitle>
- *     <CardDescription>설명</CardDescription>
- *   </CardHeader>
- *   <CardContent>내용</CardContent>
- *   <CardFooter>액션 버튼</CardFooter>
- * </Card>
+ * - 글래스모피즘 스타일
+ * - 다크 테마 최적화
+ * - Compound Component 패턴
  */
 
 import React from 'react';
@@ -36,31 +18,44 @@ interface CardProps {
   className?: string;
   /** 클릭 이벤트 핸들러 */
   onClick?: () => void;
-  /** 호버 시 그림자 효과 활성화 */
+  /** 호버 시 효과 활성화 */
   hover?: boolean;
+  /** 글로우 색상 */
+  glow?: 'neon' | 'cyan' | 'violet' | 'none';
 }
 
 /**
  * Card 컴포넌트 (메인 컨테이너)
- * 
- * 역할:
- * - 콘텐츠를 카드 형태로 감싸는 컨테이너
- * - 선택적으로 클릭 및 호버 효과 제공
- * 
- * @param {CardProps} props - 카드 속성
- * @returns {JSX.Element} 카드 컨테이너
+ * 글래스모피즘 스타일의 카드
  */
 export const Card: React.FC<CardProps> = ({ 
   children, 
   className, 
   onClick,
-  hover = false 
+  hover = false,
+  glow = 'none'
 }) => {
+  const glowStyles = {
+    neon: 'hover:shadow-neon hover:border-neon-500/30',
+    cyan: 'hover:shadow-cyan hover:border-cyan-500/30',
+    violet: 'hover:shadow-violet hover:border-violet-500/30',
+    none: ''
+  };
+
   return (
     <div
       className={cn(
-        'bg-white rounded-lg border border-gray-200 shadow-sm',
-        hover && 'hover:shadow-md transition-shadow cursor-pointer',
+        // 기본 글래스모피즘 스타일
+        'bg-white/5 backdrop-blur-xl rounded-2xl',
+        'border border-white/10',
+        'shadow-glass',
+        // 호버 효과
+        hover && [
+          'transition-all duration-300 cursor-pointer',
+          'hover:bg-white/10 hover:border-white/20',
+          'hover:-translate-y-1',
+          glowStyles[glow]
+        ],
         onClick && 'cursor-pointer',
         className
       )}
@@ -78,11 +73,11 @@ interface CardHeaderProps {
 
 /**
  * CardHeader 컴포넌트
- * - 카드의 헤더 영역 (하단 구분선 포함)
+ * - 카드의 헤더 영역
  */
 export const CardHeader: React.FC<CardHeaderProps> = ({ children, className }) => {
   return (
-    <div className={cn('px-6 py-4 border-b border-gray-200', className)}>
+    <div className={cn('px-6 py-5 border-b border-white/10', className)}>
       {children}
     </div>
   );
@@ -99,7 +94,7 @@ interface CardTitleProps {
  */
 export const CardTitle: React.FC<CardTitleProps> = ({ children, className }) => {
   return (
-    <h3 className={cn('text-lg font-semibold text-gray-900', className)}>
+    <h3 className={cn('text-lg font-semibold text-white', className)}>
       {children}
     </h3>
   );
@@ -112,11 +107,11 @@ interface CardDescriptionProps {
 
 /**
  * CardDescription 컴포넌트
- * - 카드의 설명 텍스트 (제목 하단)
+ * - 카드의 설명 텍스트
  */
 export const CardDescription: React.FC<CardDescriptionProps> = ({ children, className }) => {
   return (
-    <p className={cn('mt-1 text-sm text-gray-500', className)}>
+    <p className={cn('mt-1.5 text-sm text-slate-400', className)}>
       {children}
     </p>
   );
@@ -133,7 +128,7 @@ interface CardContentProps {
  */
 export const CardContent: React.FC<CardContentProps> = ({ children, className }) => {
   return (
-    <div className={cn('px-6 py-4', className)}>
+    <div className={cn('px-6 py-5', className)}>
       {children}
     </div>
   );
@@ -146,13 +141,12 @@ interface CardFooterProps {
 
 /**
  * CardFooter 컴포넌트
- * - 카드의 푸터 영역 (상단 구분선, 회색 배경)
+ * - 카드의 푸터 영역
  */
 export const CardFooter: React.FC<CardFooterProps> = ({ children, className }) => {
   return (
-    <div className={cn('px-6 py-4 border-t border-gray-200 bg-gray-50', className)}>
+    <div className={cn('px-6 py-4 border-t border-white/10 bg-white/5 rounded-b-2xl', className)}>
       {children}
     </div>
   );
 };
-

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -3,79 +3,59 @@
  * 
  * 파일 용도:
  * 재사용 가능한 입력 필드 컴포넌트
- * - 레이블, 에러 메시지, 도움말 텍스트 지원
- * - forwardRef로 ref 전달 가능
- * - 필수 필드 표시 (*)
- * - 표준 HTML input 속성 모두 지원
- * 
- * 사용 예시:
- * <Input
- *   label="이메일"
- *   type="email"
- *   placeholder="example@email.com"
- *   required
- *   helperText="이메일 형식으로 입력해주세요"
- *   error={errors.email}
- * />
+ * - 글래스모피즘 스타일
+ * - 다크 테마 최적화
+ * - 네온 포커스 효과
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { cn } from '../../lib/utils';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  /** 입력 필드 레이블 */
-  label?: string;
-  /** 에러 메시지 (표시 시 빨간색 스타일 적용) */
-  error?: string;
-  /** 도움말 텍스트 */
-  helperText?: string;
+  /** 에러 상태 */
+  error?: boolean;
+  /** 아이콘 (왼쪽) */
+  icon?: React.ReactNode;
 }
 
 /**
  * Input 컴포넌트
- * 
- * 역할:
- * - 폼 입력 필드 UI 제공
- * - 에러 상태 시각화
- * - 접근성 지원 (레이블, 필수 필드 표시)
- * 
- * @param {InputProps} props - 입력 필드 속성
- * @param {React.Ref<HTMLInputElement>} ref - input element ref
- * @returns {JSX.Element} 입력 필드
+ * 글래스모피즘 스타일의 입력 필드
  */
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, helperText, className, ...props }, ref) => {
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, error, icon, ...props }, ref) => {
     return (
-      <div className="w-full">
-        {label && (
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            {label}
-            {props.required && <span className="text-red-500 ml-1">*</span>}
-          </label>
+      <div className="relative">
+        {icon && (
+          <div className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500">
+            {icon}
+          </div>
         )}
         <input
           ref={ref}
           className={cn(
-            'w-full px-3 py-2 border rounded-lg shadow-sm transition-colors',
-            'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500',
-            error
-              ? 'border-red-300 focus:ring-red-500 focus:border-red-500'
-              : 'border-gray-300',
-            'disabled:bg-gray-100 disabled:cursor-not-allowed',
+            // 기본 스타일
+            'w-full px-4 py-3 rounded-xl',
+            'bg-white/5 backdrop-blur-sm',
+            'border border-white/10',
+            'text-white placeholder-slate-500',
+            // 포커스 스타일
+            'focus:outline-none focus:border-neon-500/50',
+            'focus:ring-2 focus:ring-neon-500/20',
+            'focus:bg-white/10',
+            // 트랜지션
+            'transition-all duration-300',
+            // 에러 스타일
+            error && 'border-red-500/50 focus:border-red-500 focus:ring-red-500/20',
+            // 아이콘이 있을 때 패딩 조정
+            icon && 'pl-12',
             className
           )}
           {...props}
         />
-        {helperText && !error && (
-          <p className="mt-1 text-sm text-gray-500">{helperText}</p>
-        )}
-        {error && (
-          <p className="mt-1 text-sm text-red-600">{error}</p>
-        )}
       </div>
     );
   }
 );
 
 Input.displayName = 'Input';
-

--- a/src/components/ui/Progress.tsx
+++ b/src/components/ui/Progress.tsx
@@ -2,67 +2,61 @@
  * 파일명: Progress.tsx
  * 
  * 파일 용도:
- * 재사용 가능한 진행률 표시 컴포넌트
- * - 0-100% 진행률을 시각적으로 표시
- * - 선택적으로 퍼센트 레이블 표시
- * - 부드러운 애니메이션 효과
- * 
- * 사용 예시:
- * <Progress value={75} max={100} showLabel />
- * <Progress value={completedSteps} max={totalSteps} />
+ * 진행률 바 컴포넌트
+ * - 네온 그라디언트 스타일
+ * - 애니메이션 효과
  */
 
 import React from 'react';
 import { cn } from '../../lib/utils';
 
 interface ProgressProps {
-  /** 현재 진행 값 */
+  /** 진행률 (0-100) */
   value: number;
-  /** 최대 값 (기본값: 100) */
-  max?: number;
+  /** 레이블 표시 여부 */
+  showLabel?: boolean;
   /** 추가 CSS 클래스 */
   className?: string;
-  /** 퍼센트 레이블 표시 여부 */
-  showLabel?: boolean;
+  /** 색상 테마 */
+  color?: 'neon' | 'cyan' | 'violet';
 }
 
 /**
  * Progress 컴포넌트
- * 
- * 역할:
- * - 작업 진행 상황을 시각적으로 표시
- * - 마법사 단계, 파일 업로드 등에 활용
- * 
- * 특징:
- * - 자동으로 0-100% 범위로 정규화
- * - 부드러운 transition 효과
- * 
- * @param {ProgressProps} props - 진행률 속성
- * @returns {JSX.Element} 진행률 바
+ * 네온 스타일 진행률 바
  */
-export const Progress: React.FC<ProgressProps> = ({ 
-  value, 
-  max = 100, 
+export const Progress: React.FC<ProgressProps> = ({
+  value,
+  showLabel = false,
   className,
-  showLabel = false 
+  color = 'neon'
 }) => {
-  // 퍼센트 계산 (0-100% 범위로 제한)
-  const percentage = Math.min(Math.max((value / max) * 100, 0), 100);
+  const clampedValue = Math.min(100, Math.max(0, value));
+  
+  const colorStyles = {
+    neon: 'from-neon-400 to-neon-500 shadow-neon-500/30',
+    cyan: 'from-cyan-400 to-cyan-500 shadow-cyan-500/30',
+    violet: 'from-violet-400 to-violet-500 shadow-violet-500/30',
+  };
 
   return (
     <div className={cn('w-full', className)}>
-      <div className="relative w-full h-2 bg-gray-200 rounded-full overflow-hidden">
-        <div
-          className="absolute top-0 left-0 h-full bg-primary-600 transition-all duration-300 ease-in-out"
-          style={{ width: `${percentage}%` }}
-        />
-      </div>
       {showLabel && (
-        <div className="mt-1 text-xs text-gray-600 text-right">
-          {Math.round(percentage)}%
+        <div className="flex justify-between text-sm mb-2">
+          <span className="text-slate-400">진행률</span>
+          <span className="text-white font-medium">{Math.round(clampedValue)}%</span>
         </div>
       )}
+      <div className="h-2 bg-white/10 rounded-full overflow-hidden backdrop-blur-sm">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-500 ease-out',
+            'bg-gradient-to-r shadow-lg',
+            colorStyles[color]
+          )}
+          style={{ width: `${clampedValue}%` }}
+        />
+      </div>
     </div>
   );
 };
-

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -2,46 +2,46 @@
  * 파일명: Spinner.tsx
  * 
  * 파일 용도:
- * 재사용 가능한 로딩 스피너 컴포넌트
- * - 로딩 중임을 나타내는 회전 애니메이션
- * - 3가지 크기 옵션 (sm, md, lg)
- * - SVG 기반으로 선명한 표시
- * 
- * 사용 예시:
- * <Spinner size="lg" />
- * <Spinner size="sm" className="text-white" />
+ * 로딩 스피너 컴포넌트
+ * - 네온 스타일
  */
 
 import React from 'react';
 import { cn } from '../../lib/utils';
 
 interface SpinnerProps {
-  /** 스피너 크기 */
+  /** 크기 */
   size?: 'sm' | 'md' | 'lg';
   /** 추가 CSS 클래스 */
   className?: string;
+  /** 색상 */
+  color?: 'neon' | 'cyan' | 'violet' | 'white';
 }
 
 /**
  * Spinner 컴포넌트
- * 
- * 역할:
- * - 데이터 로딩, 처리 중 상태 표시
- * - 부드러운 회전 애니메이션
- * 
- * @param {SpinnerProps} props - 스피너 속성
- * @returns {JSX.Element} 로딩 스피너
  */
-export const Spinner: React.FC<SpinnerProps> = ({ size = 'md', className }) => {
+export const Spinner: React.FC<SpinnerProps> = ({
+  size = 'md',
+  className,
+  color = 'neon'
+}) => {
   const sizes = {
-    sm: 'h-4 w-4',
-    md: 'h-8 w-8',
-    lg: 'h-12 w-12',
+    sm: 'w-4 h-4',
+    md: 'w-8 h-8',
+    lg: 'w-12 h-12',
+  };
+
+  const colors = {
+    neon: 'text-neon-500',
+    cyan: 'text-cyan-500',
+    violet: 'text-violet-500',
+    white: 'text-white',
   };
 
   return (
     <svg
-      className={cn('animate-spin text-primary-600', sizes[size], className)}
+      className={cn('animate-spin', sizes[size], colors[color], className)}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
@@ -62,4 +62,3 @@ export const Spinner: React.FC<SpinnerProps> = ({ size = 'md', className }) => {
     </svg>
   );
 };
-

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -2,80 +2,52 @@
  * 파일명: Textarea.tsx
  * 
  * 파일 용도:
- * 재사용 가능한 여러 줄 텍스트 입력 컴포넌트
- * - 레이블, 에러 메시지, 도움말 텍스트 지원
- * - forwardRef로 ref 전달 가능
- * - 세로 크기 조절 가능 (resize-y)
- * - 표준 HTML textarea 속성 모두 지원
- * 
- * 사용 예시:
- * <Textarea
- *   label="사업 개요"
- *   placeholder="사업에 대해 설명해주세요"
- *   rows={6}
- *   required
- *   helperText="최소 100자 이상 입력해주세요"
- * />
+ * 재사용 가능한 텍스트 영역 컴포넌트
+ * - 글래스모피즘 스타일
+ * - 다크 테마 최적화
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { cn } from '../../lib/utils';
 
 interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
-  /** 텍스트 영역 레이블 */
-  label?: string;
-  /** 에러 메시지 */
-  error?: string;
-  /** 도움말 텍스트 */
-  helperText?: string;
+  /** 에러 상태 */
+  error?: boolean;
 }
 
 /**
  * Textarea 컴포넌트
- * 
- * 역할:
- * - 긴 텍스트 입력을 위한 UI 제공
- * - Input 컴포넌트와 일관된 스타일
- * - 에러 상태 시각화
- * 
- * @param {TextareaProps} props - 텍스트 영역 속성
- * @param {React.Ref<HTMLTextAreaElement>} ref - textarea element ref
- * @returns {JSX.Element} 텍스트 영역
+ * 글래스모피즘 스타일의 텍스트 영역
  */
-export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ label, error, helperText, className, ...props }, ref) => {
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, error, ...props }, ref) => {
     return (
-      <div className="w-full">
-        {label && (
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            {label}
-            {props.required && <span className="text-red-500 ml-1">*</span>}
-          </label>
+      <textarea
+        ref={ref}
+        className={cn(
+          // 기본 스타일
+          'w-full px-4 py-3 rounded-xl',
+          'bg-white/5 backdrop-blur-sm',
+          'border border-white/10',
+          'text-white placeholder-slate-500',
+          // 포커스 스타일
+          'focus:outline-none focus:border-neon-500/50',
+          'focus:ring-2 focus:ring-neon-500/20',
+          'focus:bg-white/10',
+          // 트랜지션
+          'transition-all duration-300',
+          // 리사이즈
+          'resize-none',
+          // 스크롤바 스타일
+          'scrollbar-thin scrollbar-thumb-white/20 scrollbar-track-transparent',
+          // 에러 스타일
+          error && 'border-red-500/50 focus:border-red-500 focus:ring-red-500/20',
+          className
         )}
-        <textarea
-          ref={ref}
-          rows={4}
-          className={cn(
-            'w-full px-3 py-2 border rounded-lg shadow-sm transition-colors resize-y',
-            'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500',
-            error
-              ? 'border-red-300 focus:ring-red-500 focus:border-red-500'
-              : 'border-gray-300',
-            'disabled:bg-gray-100 disabled:cursor-not-allowed',
-            className
-          )}
-          {...props}
-        />
-        {helperText && !error && (
-          <p className="mt-1 text-sm text-gray-500">{helperText}</p>
-        )}
-        {error && (
-          <p className="mt-1 text-sm text-red-600">{error}</p>
-        )}
-      </div>
+        {...props}
+      />
     );
   }
 );
 
 Textarea.displayName = 'Textarea';
-

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,178 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Sora:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --neon-green: #22c55e;
+    --neon-cyan: #06b6d4;
+    --neon-violet: #8b5cf6;
+    --color-neon-400: #4ade80;
+    --color-neon-500: #22c55e;
+    --color-cyan-400: #22d3ee;
+    --color-cyan-500: #06b6d4;
+    --color-violet-400: #a78bfa;
+    --color-violet-500: #8b5cf6;
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
-    @apply bg-gray-50 text-gray-900 antialiased;
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    background-color: #020617;
+    color: #f1f5f9;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    background-image: 
+      radial-gradient(ellipse 80% 80% at 50% -20%, rgba(139, 92, 246, 0.15), transparent),
+      radial-gradient(ellipse 60% 60% at 100% 100%, rgba(6, 182, 212, 0.1), transparent);
+    min-height: 100vh;
+  }
+
+  ::selection {
+    background-color: rgba(34, 197, 94, 0.3);
+    color: white;
+  }
+}
+
+@layer components {
+  /* 글래스모피즘 카드 */
+  .glass-card {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    box-shadow: 
+      0 8px 32px rgba(0, 0, 0, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  }
+
+  .glass-card-hover {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    transition: all 0.3s ease;
+  }
+
+  .glass-card-hover:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.2);
+    box-shadow: 
+      0 16px 48px rgba(0, 0, 0, 0.4),
+      0 0 40px rgba(34, 197, 94, 0.1),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    transform: translateY(-4px);
+  }
+
+  /* 네온 글로우 버튼 */
+  .btn-neon {
+    position: relative;
+    padding: 1rem 2rem;
+    border-radius: 0.75rem;
+    font-weight: 600;
+    color: #0f172a;
+    background: linear-gradient(135deg, #22c55e 0%, #4ade80 100%);
+    box-shadow: 
+      0 4px 20px rgba(34, 197, 94, 0.4),
+      inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .btn-neon:hover {
+    transform: translateY(-2px);
+    box-shadow: 
+      0 8px 40px rgba(34, 197, 94, 0.6),
+      inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  }
+
+  .btn-neon:active {
+    transform: translateY(0);
+  }
+
+  /* 테두리 그라디언트 효과 */
+  .border-gradient {
+    position: relative;
+    background: linear-gradient(135deg, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0.05) 100%);
+    border-radius: 1rem;
+  }
+
+  .border-gradient::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    padding: 1px;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(34,197,94,0.5) 0%, rgba(6,182,212,0.3) 50%, rgba(139,92,246,0.5) 100%);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+  }
+
+  /* 입력 필드 스타일 */
+  .input-glass {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0.75rem;
+    color: white;
+    transition: all 0.3s ease;
+  }
+
+  .input-glass::placeholder {
+    color: #64748b;
+  }
+
+  .input-glass:focus {
+    outline: none;
+    border-color: rgba(34, 197, 94, 0.5);
+    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2), 0 0 20px rgba(34, 197, 94, 0.15);
+  }
+
+  /* 텍스트 그라디언트 */
+  .text-gradient {
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    background-image: linear-gradient(135deg, #22c55e 0%, #06b6d4 50%, #8b5cf6 100%);
+  }
+
+  .text-gradient-cyan {
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    background-image: linear-gradient(135deg, #06b6d4 0%, #8b5cf6 100%);
+  }
+
+  /* 플로팅 오브 */
+  .floating-orb {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(48px);
+    opacity: 0.3;
+    animation: float 8s ease-in-out infinite;
+  }
+
+  /* 그리드 패턴 배경 */
+  .bg-grid {
+    background-image: 
+      linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+    background-size: 60px 60px;
+  }
+
+  /* 도트 패턴 배경 */
+  .bg-dots {
+    background-image: radial-gradient(rgba(255,255,255,0.1) 1px, transparent 1px);
+    background-size: 20px 20px;
   }
 }
 
@@ -13,4 +180,32 @@
   .text-balance {
     text-wrap: balance;
   }
+
+  .animate-delay-100 {
+    animation-delay: 100ms;
+  }
+
+  .animate-delay-200 {
+    animation-delay: 200ms;
+  }
+
+  .animate-delay-300 {
+    animation-delay: 300ms;
+  }
+
+  .animate-delay-400 {
+    animation-delay: 400ms;
+  }
+
+  .delay-100 { animation-delay: 100ms; }
+  .delay-200 { animation-delay: 200ms; }
+  .delay-300 { animation-delay: 300ms; }
+  .delay-400 { animation-delay: 400ms; }
+  .delay-500 { animation-delay: 500ms; }
+}
+
+/* 키프레임 애니메이션 */
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-20px); }
 }

--- a/src/pages/ProjectCreate.tsx
+++ b/src/pages/ProjectCreate.tsx
@@ -6,21 +6,7 @@
  * - 사용자로부터 프로젝트명과 템플릿 선택을 받음
  * - 프로젝트 생성 후 마법사 단계로 이동
  * 
- * 호출 구조:
- * ProjectCreate (이 컴포넌트)
- *   ├─> useProjectStore.createProject() - 프로젝트 생성
- *   ├─> useWizardStore.resetWizard() - 마법사 상태 초기화
- *   └─> navigate('/wizard/1') - 첫 번째 마법사 단계로 이동
- * 
- * 데이터 흐름:
- * 1. 사용자 입력 (프로젝트명, 템플릿) → 로컬 state
- * 2. 제출 시 → useProjectStore에 저장
- * 3. 마법사 초기화 → useWizardStore.resetWizard()
- * 4. 페이지 이동 → /wizard/1
- * 
- * 사용하는 Store:
- * - useProjectStore: 프로젝트 정보 관리
- * - useWizardStore: 마법사 진행 상태 관리
+ * 디자인: 다크 모드 + 글래스모피즘 + 네온 액센트
  */
 
 import React, { useState } from 'react';
@@ -29,45 +15,35 @@ import { useProjectStore } from '../stores/useProjectStore';
 import { useWizardStore } from '../stores/useWizardStore';
 import { templates } from '../types/mockData';
 import { TemplateType } from '../types';
-import { Button, Input, Card, CardHeader, CardTitle, CardDescription, CardContent } from '../components/ui';
-import { Rocket } from 'lucide-react';
+import { 
+  Rocket, 
+  Sparkles, 
+  TrendingUp, 
+  Target, 
+  ArrowRight,
+  Check,
+  Zap,
+  BarChart3,
+  FileText
+} from 'lucide-react';
+import { cn } from '../lib/utils';
 
 /**
  * ProjectCreate 컴포넌트
- * 
- * 역할:
- * - 신규 프로젝트 생성을 위한 초기 설정 페이지
- * - 프로젝트 이름과 템플릿 선택 UI 제공
- * - 입력 유효성 검증 및 에러 처리
- * 
- * 주요 기능:
- * 1. 프로젝트명 입력 폼
- * 2. 템플릿 선택 (스타트업/소상공인/프리랜서)
- * 3. 입력 유효성 검증
- * 4. 프로젝트 생성 및 마법사로 이동
- * 
- * @returns {JSX.Element} 프로젝트 생성 페이지
+ * 신규 프로젝트 생성을 위한 초기 설정 페이지
  */
 export const ProjectCreate: React.FC = () => {
   const navigate = useNavigate();
   const { createProject } = useProjectStore();
   const { resetWizard } = useWizardStore();
-  // Local state
+
   const [projectName, setProjectName] = useState('');
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateType | null>(null);
   const [error, setError] = useState('');
+  const [isHovered, setIsHovered] = useState<string | null>(null);
 
   /**
    * 폼 제출 핸들러
-   * 
-   * 처리 순서:
-   * 1. 프로젝트명 유효성 검증
-   * 2. 템플릿 선택 여부 검증
-   * 3. useProjectStore.createProject() 호출
-   * 4. useWizardStore.resetWizard() 호출
-   * 5. /wizard/1 경로로 이동
-   * 
-   * @param {React.FormEvent} e - 폼 제출 이벤트
    */
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -82,137 +58,272 @@ export const ProjectCreate: React.FC = () => {
       return;
     }
 
-    // Create new project
     createProject(projectName, selectedTemplate);
     resetWizard();
-    
-    // Navigate to wizard
     navigate('/wizard/1');
   };
 
+  // 템플릿 아이콘 매핑 (mockData.ts의 ID와 일치)
+  const templateIcons: Record<string, React.ReactNode> = {
+    'pre-startup': <Rocket className="w-8 h-8" />,
+    'early-startup': <TrendingUp className="w-8 h-8" />,
+    'bank-loan': <Target className="w-8 h-8" />,
+  };
+
+  // 템플릿 색상 매핑
+  const templateColors: Record<string, { bg: string; border: string; glow: string }> = {
+    'pre-startup': { 
+      bg: 'from-neon-500/20 to-neon-600/10', 
+      border: 'border-neon-500/30',
+      glow: 'shadow-neon'
+    },
+    'early-startup': { 
+      bg: 'from-cyan-500/20 to-cyan-600/10', 
+      border: 'border-cyan-500/30',
+      glow: 'shadow-cyan'
+    },
+    'bank-loan': { 
+      bg: 'from-violet-500/20 to-violet-600/10', 
+      border: 'border-violet-500/30',
+      glow: 'shadow-violet'
+    },
+  };
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-50 via-white to-blue-50">
-      <div className="container mx-auto px-4 py-16">
-        <div className="max-w-4xl mx-auto">
-          {/* Header */}
-          <div className="text-center mb-12">
-            <div className="inline-flex items-center justify-center w-16 h-16 bg-primary-600 rounded-2xl mb-4">
-              <Rocket className="w-8 h-8 text-white" />
+    <div className="min-h-screen relative overflow-hidden">
+      {/* 배경 효과 */}
+      <div className="absolute inset-0 bg-grid opacity-50" />
+      
+      {/* 플로팅 오브 */}
+      <div className="floating-orb w-96 h-96 bg-neon-500/20 -top-48 -left-48" />
+      <div className="floating-orb w-80 h-80 bg-cyan-500/20 top-1/3 -right-40" style={{ animationDelay: '2s' }} />
+      <div className="floating-orb w-64 h-64 bg-violet-500/20 bottom-20 left-1/4" style={{ animationDelay: '4s' }} />
+
+      {/* 메인 콘텐츠 */}
+      <div className="relative z-10 container mx-auto px-4 py-16">
+        <div className="max-w-5xl mx-auto">
+          
+          {/* 헤더 섹션 */}
+          <div className="text-center mb-16 animate-fade-in">
+            {/* 로고/아이콘 */}
+            <div className="inline-flex items-center justify-center mb-6">
+              <div className="relative">
+                <div className="absolute inset-0 bg-neon-500 blur-2xl opacity-40 animate-pulse-slow" />
+                <div className="relative w-20 h-20 rounded-2xl bg-gradient-to-br from-neon-400 to-neon-600 flex items-center justify-center shadow-neon-lg">
+                  <Sparkles className="w-10 h-10 text-slate-900" />
+                </div>
+              </div>
             </div>
-            <h1 className="text-4xl font-bold text-gray-900 mb-4">
-              사업계획서 작성 시작하기
+
+            {/* 타이틀 */}
+            <h1 className="text-5xl md:text-6xl font-display font-bold mb-6">
+              <span className="text-white">AI로 완성하는</span>
+              <br />
+              <span className="text-gradient">사업계획서</span>
             </h1>
-            <p className="text-lg text-gray-600">
-              AI가 도와주는 전문가급 사업계획서를 5단계로 완성하세요
+
+            <p className="text-xl text-slate-400 max-w-2xl mx-auto leading-relaxed">
+              복잡한 서류 작성은 이제 그만.
+              <br className="hidden md:block" />
+              <span className="text-slate-300">5단계 마법사</span>로 전문가급 사업계획서를 완성하세요.
             </p>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-8">
-            {/* Project Name */}
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                프로젝트 이름
-              </h2>
-              <Input
-                placeholder="예: 우리 회사의 새로운 사업"
+          {/* 폼 영역 */}
+          <form onSubmit={handleSubmit} className="space-y-10">
+            
+            {/* 프로젝트 이름 입력 */}
+            <div className="glass-card p-8 animate-slide-up">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-10 h-10 rounded-lg bg-neon-500/20 flex items-center justify-center">
+                  <FileText className="w-5 h-5 text-neon-400" />
+                </div>
+                <h2 className="text-xl font-semibold text-white">프로젝트 이름</h2>
+              </div>
+              
+              <input
+                type="text"
+                className="input-glass text-lg"
+                placeholder="예: 혁신적인 AI 스타트업 사업계획"
                 value={projectName}
                 onChange={(e) => {
                   setProjectName(e.target.value);
                   setError('');
                 }}
-                required
               />
             </div>
 
-            {/* Template Selection */}
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                템플릿 선택
-              </h2>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                {templates.map((template) => (
-                  <Card
-                    key={template.id}
-                    className={`cursor-pointer transition-all ${
-                      selectedTemplate === template.id
-                        ? 'ring-2 ring-primary-600 border-primary-600'
-                        : 'hover:border-primary-300'
-                    }`}
-                    onClick={() => {
-                      setSelectedTemplate(template.id);
-                      setError('');
-                    }}
-                  >
-                    <CardHeader>
-                      <div className="text-4xl mb-2">{template.icon}</div>
-                      <CardTitle className="text-base">{template.name}</CardTitle>
-                      <CardDescription className="text-xs">
+            {/* 템플릿 선택 */}
+            <div className="glass-card p-8 animate-slide-up delay-100">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-10 h-10 rounded-lg bg-cyan-500/20 flex items-center justify-center">
+                  <Zap className="w-5 h-5 text-cyan-400" />
+                </div>
+                <h2 className="text-xl font-semibold text-white">템플릿 선택</h2>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                {templates.map((template) => {
+                  const isSelected = selectedTemplate === template.id;
+                  const colors = templateColors[template.id] || templateColors['pre-startup'];
+                  
+                  return (
+                    <button
+                      key={template.id}
+                      type="button"
+                      className={cn(
+                        'relative p-6 rounded-xl text-left transition-all duration-300',
+                        'bg-gradient-to-br border',
+                        colors.bg,
+                        isSelected 
+                          ? `${colors.border} ${colors.glow}` 
+                          : 'border-white/10 hover:border-white/20',
+                        isSelected && 'scale-[1.02]',
+                        'group'
+                      )}
+                      onClick={() => {
+                        setSelectedTemplate(template.id);
+                        setError('');
+                      }}
+                      onMouseEnter={() => setIsHovered(template.id)}
+                      onMouseLeave={() => setIsHovered(null)}
+                    >
+                      {/* 선택 체크마크 */}
+                      {isSelected && (
+                        <div className="absolute top-4 right-4 w-6 h-6 rounded-full bg-neon-500 flex items-center justify-center animate-scale-in">
+                          <Check className="w-4 h-4 text-slate-900" />
+                        </div>
+                      )}
+
+                      {/* 아이콘 */}
+                      <div className={cn(
+                        'w-14 h-14 rounded-xl mb-4 flex items-center justify-center transition-all duration-300',
+                        isSelected 
+                          ? 'bg-white/20 text-white' 
+                          : 'bg-white/5 text-slate-400 group-hover:bg-white/10 group-hover:text-white'
+                      )}>
+                        {templateIcons[template.id]}
+                      </div>
+
+                      {/* 템플릿 정보 */}
+                      <h3 className={cn(
+                        'text-lg font-semibold mb-2 transition-colors',
+                        isSelected ? 'text-white' : 'text-slate-200'
+                      )}>
+                        {template.name}
+                      </h3>
+                      
+                      <p className="text-sm text-slate-400 mb-4 line-clamp-2">
                         {template.description}
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                      <ul className="space-y-1">
-                        {template.features.map((feature, index) => (
-                          <li key={index} className="flex items-start gap-2 text-xs text-gray-600">
-                            <span className="text-primary-600 mt-0.5">✓</span>
-                            <span>{feature}</span>
+                      </p>
+
+                      {/* 특징 목록 */}
+                      <ul className="space-y-2">
+                        {template.features.slice(0, 3).map((feature, index) => (
+                          <li 
+                            key={index} 
+                            className="flex items-start gap-2 text-xs text-slate-500"
+                          >
+                            <span className={cn(
+                              'mt-0.5 transition-colors',
+                              isSelected ? 'text-neon-400' : 'text-slate-600'
+                            )}>
+                              ✦
+                            </span>
+                            <span className={isSelected ? 'text-slate-300' : ''}>
+                              {feature}
+                            </span>
                           </li>
                         ))}
                       </ul>
-                    </CardContent>
-                  </Card>
-                ))}
+                    </button>
+                  );
+                })}
               </div>
             </div>
 
-            {/* Error Message */}
+            {/* 에러 메시지 */}
             {error && (
-              <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-600">
-                {error}
+              <div className="glass-card border-red-500/30 bg-red-500/10 p-4 animate-scale-in">
+                <p className="text-red-400 text-sm flex items-center gap-2">
+                  <span className="w-5 h-5 rounded-full bg-red-500/20 flex items-center justify-center text-xs">!</span>
+                  {error}
+                </p>
               </div>
             )}
 
-            {/* Submit Button */}
-            <div className="flex justify-center">
-              <Button type="submit" size="lg" className="px-8">
-                사업계획서 작성 시작하기
-              </Button>
+            {/* 제출 버튼 */}
+            <div className="flex justify-center pt-4 animate-slide-up delay-200">
+              <button
+                type="submit"
+                className="btn-neon group flex items-center gap-3 text-lg"
+              >
+                <span>사업계획서 작성 시작</span>
+                <ArrowRight className="w-5 h-5 transition-transform group-hover:translate-x-1" />
+              </button>
             </div>
           </form>
 
-          {/* Features */}
-          <div className="mt-16 grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="text-center">
-              <div className="w-12 h-12 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                <span className="text-2xl">🤖</span>
+          {/* 기능 소개 섹션 */}
+          <div className="mt-24 grid grid-cols-1 md:grid-cols-3 gap-6 animate-fade-in delay-300">
+            {[
+              {
+                icon: <Sparkles className="w-6 h-6" />,
+                title: 'AI 자동 작성',
+                description: '입력한 내용을 바탕으로 AI가 전문적인 사업계획서를 자동 생성합니다',
+                color: 'neon'
+              },
+              {
+                icon: <BarChart3 className="w-6 h-6" />,
+                title: '재무 시뮬레이션',
+                description: '실시간 차트로 손익분기점과 수익성을 한눈에 확인하세요',
+                color: 'cyan'
+              },
+              {
+                icon: <Target className="w-6 h-6" />,
+                title: 'PMF 진단',
+                description: '제품-시장 적합성을 진단하고 성공 가능성을 높이세요',
+                color: 'violet'
+              }
+            ].map((feature, index) => (
+              <div 
+                key={index}
+                className="glass-card p-6 text-center group hover:bg-white/10 transition-all duration-300"
+                style={{ animationDelay: `${400 + index * 100}ms` }}
+              >
+                <div className={cn(
+                  'w-14 h-14 rounded-xl mx-auto mb-4 flex items-center justify-center transition-all duration-300',
+                  feature.color === 'neon' && 'bg-neon-500/20 text-neon-400 group-hover:bg-neon-500/30',
+                  feature.color === 'cyan' && 'bg-cyan-500/20 text-cyan-400 group-hover:bg-cyan-500/30',
+                  feature.color === 'violet' && 'bg-violet-500/20 text-violet-400 group-hover:bg-violet-500/30',
+                )}>
+                  {feature.icon}
+                </div>
+                <h3 className="font-semibold text-white mb-2">{feature.title}</h3>
+                <p className="text-sm text-slate-400 leading-relaxed">
+                  {feature.description}
+                </p>
               </div>
-              <h3 className="font-semibold text-gray-900 mb-1">AI 자동 작성</h3>
-              <p className="text-sm text-gray-600">
-                입력한 내용을 바탕으로 AI가 전문적인 사업계획서를 생성합니다
-              </p>
-            </div>
-            <div className="text-center">
-              <div className="w-12 h-12 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                <span className="text-2xl">📊</span>
-              </div>
-              <h3 className="font-semibold text-gray-900 mb-1">재무 시뮬레이션</h3>
-              <p className="text-sm text-gray-600">
-                실시간 차트로 손익분기점과 수익성을 한눈에 확인하세요
-              </p>
-            </div>
-            <div className="text-center">
-              <div className="w-12 h-12 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                <span className="text-2xl">🎯</span>
-              </div>
-              <h3 className="font-semibold text-gray-900 mb-1">PMF 진단</h3>
-              <p className="text-sm text-gray-600">
-                제품-시장 적합성을 진단하고 개선 방향을 제시합니다
-              </p>
-            </div>
+            ))}
+          </div>
+
+          {/* 하단 배지 */}
+          <div className="mt-16 flex justify-center gap-6 text-sm text-slate-500 animate-fade-in delay-500">
+            <span className="flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-neon-500 animate-pulse" />
+              30분 만에 완성
+            </span>
+            <span className="flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-cyan-500 animate-pulse" />
+              정부지원 양식 호환
+            </span>
+            <span className="flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-violet-500 animate-pulse" />
+              자동 저장
+            </span>
           </div>
         </div>
       </div>
     </div>
   );
 };
-

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,36 +7,136 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: {
-          50: '#eff6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
+        // 다크 테마 기본 색상
+        dark: {
+          50: '#1a1a2e',
+          100: '#16162a',
+          200: '#0f0f1a',
+          300: '#0a0a12',
+          400: '#050508',
+          500: '#000000',
         },
-        gray: {
-          50: '#f9fafb',
-          100: '#f3f4f6',
-          200: '#e5e7eb',
-          300: '#d1d5db',
-          400: '#9ca3af',
-          500: '#6b7280',
-          600: '#4b5563',
-          700: '#374151',
-          800: '#1f2937',
-          900: '#111827',
-        }
+        // 네온 그린 액센트
+        neon: {
+          50: '#f0fdf4',
+          100: '#dcfce7',
+          200: '#bbf7d0',
+          300: '#86efac',
+          400: '#4ade80',
+          500: '#22c55e',
+          600: '#16a34a',
+          700: '#15803d',
+          800: '#166534',
+          900: '#14532d',
+        },
+        // 시안 액센트
+        cyan: {
+          50: '#ecfeff',
+          100: '#cffafe',
+          200: '#a5f3fc',
+          300: '#67e8f9',
+          400: '#22d3ee',
+          500: '#06b6d4',
+          600: '#0891b2',
+          700: '#0e7490',
+          800: '#155e75',
+          900: '#164e63',
+        },
+        // 보라 액센트
+        violet: {
+          50: '#f5f3ff',
+          100: '#ede9fe',
+          200: '#ddd6fe',
+          300: '#c4b5fd',
+          400: '#a78bfa',
+          500: '#8b5cf6',
+          600: '#7c3aed',
+          700: '#6d28d9',
+          800: '#5b21b6',
+          900: '#4c1d95',
+        },
+        // 그레이 (다크 테마용)
+        slate: {
+          50: '#f8fafc',
+          100: '#f1f5f9',
+          200: '#e2e8f0',
+          300: '#cbd5e1',
+          400: '#94a3b8',
+          500: '#64748b',
+          600: '#475569',
+          700: '#334155',
+          800: '#1e293b',
+          900: '#0f172a',
+          950: '#020617',
+        },
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: ['Outfit', 'system-ui', 'sans-serif'],
+        display: ['Sora', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'monospace'],
+      },
+      animation: {
+        'float': 'float 6s ease-in-out infinite',
+        'pulse-slow': 'pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+        'glow': 'glow 2s ease-in-out infinite alternate',
+        'gradient': 'gradient 8s ease infinite',
+        'slide-up': 'slideUp 0.5s ease-out',
+        'slide-down': 'slideDown 0.5s ease-out',
+        'fade-in': 'fadeIn 0.6s ease-out',
+        'scale-in': 'scaleIn 0.3s ease-out',
+        'shimmer': 'shimmer 2s linear infinite',
+      },
+      keyframes: {
+        float: {
+          '0%, 100%': { transform: 'translateY(0px)' },
+          '50%': { transform: 'translateY(-20px)' },
+        },
+        glow: {
+          '0%': { boxShadow: '0 0 20px rgba(34, 197, 94, 0.3)' },
+          '100%': { boxShadow: '0 0 40px rgba(34, 197, 94, 0.6)' },
+        },
+        gradient: {
+          '0%, 100%': { backgroundPosition: '0% 50%' },
+          '50%': { backgroundPosition: '100% 50%' },
+        },
+        slideUp: {
+          '0%': { transform: 'translateY(20px)', opacity: '0' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
+        },
+        slideDown: {
+          '0%': { transform: 'translateY(-20px)', opacity: '0' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
+        },
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        scaleIn: {
+          '0%': { transform: 'scale(0.9)', opacity: '0' },
+          '100%': { transform: 'scale(1)', opacity: '1' },
+        },
+        shimmer: {
+          '0%': { backgroundPosition: '-200% 0' },
+          '100%': { backgroundPosition: '200% 0' },
+        },
+      },
+      backgroundImage: {
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+        'mesh-gradient': 'linear-gradient(135deg, #0f172a 0%, #1e1b4b 50%, #0f172a 100%)',
+      },
+      backdropBlur: {
+        xs: '2px',
+      },
+      boxShadow: {
+        'neon': '0 0 20px rgba(34, 197, 94, 0.4)',
+        'neon-lg': '0 0 40px rgba(34, 197, 94, 0.6)',
+        'cyan': '0 0 20px rgba(6, 182, 212, 0.4)',
+        'violet': '0 0 20px rgba(139, 92, 246, 0.4)',
+        'glass': '0 8px 32px rgba(0, 0, 0, 0.3)',
+        'glass-lg': '0 16px 48px rgba(0, 0, 0, 0.4)',
       },
     },
   },
   plugins: [],
 }
-


### PR DESCRIPTION
## 📋 변경 사항 요약

기존의 평범한 라이트 블루 테마를 **모던 다크 테마 + 글래스모피즘 + 네온 액센트** 스타일로 전면 리디자인했습니다.

### 🎨 디자인 변경 내용

| 요소 | 이전 | 이후 |
|------|------|------|
| **테마** | 라이트 블루 | 다크 모드 (네이비/슬레이트) |
| **액센트 컬러** | 단일 파란색 | 네온 그린 + 시안 + 바이올렛 |
| **카드 스타일** | 일반 흰색 카드 | 글래스모피즘 (반투명 블러) |
| **배경** | 단색 그라디언트 | 그라디언트 오브 + 그리드 패턴 |
| **폰트** | Inter | Outfit + Sora |
| **애니메이션** | 없음 | fade-in, slide-up, floating |
| **버튼** | 단색 | 네온 글로우 효과 |

### 📁 변경된 파일

- `tailwind.config.js`: 새 색상 팔레트, 폰트, 애니메이션 추가
- `src/index.css`: 글로벌 다크 테마 스타일, 글래스모피즘 유틸리티 클래스
- `src/components/ui/*`: 모든 UI 컴포넌트 다크 테마 적용
- `src/components/Layout.tsx`: 다크 테마 레이아웃
- `src/components/SaveIndicator.tsx`: 저장 상태 배지 스타일
- `src/pages/ProjectCreate.tsx`: 메인 페이지 전면 리디자인

### ✅ 체크리스트

- [x] 다크 테마 적용
- [x] 글래스모피즘 스타일 적용
- [x] 네온 액센트 컬러 적용
- [x] 애니메이션 효과 추가
- [x] 템플릿 ID 매핑 수정 (mockData.ts와 일치)
- [x] 린트 에러 없음