### PR TITLE
fix(Modal): 다중 모달 오픈 시 body 스크롤 관리 버그 수정

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -13,6 +13,27 @@ import React, { useEffect, useCallback, ReactNode } from 'react';
 import { X } from 'lucide-react';
 import { cn } from '../../lib/utils';
 
+/**
+ * 열린 모달 개수를 추적하여 body 스크롤을 관리
+ * - 첫 번째 모달이 열릴 때만 스크롤 잠금
+ * - 마지막 모달이 닫힐 때만 스크롤 해제
+ */
+let openModalCount = 0;
+
+const lockBodyScroll = (): void => {
+  openModalCount++;
+  if (openModalCount === 1) {
+    document.body.style.overflow = 'hidden';
+  }
+};
+
+const unlockBodyScroll = (): void => {
+  openModalCount = Math.max(0, openModalCount - 1);
+  if (openModalCount === 0) {
+    document.body.style.overflow = 'unset';
+  }
+};
+
 export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -56,12 +77,16 @@ export const Modal: React.FC<ModalProps> = ({
   useEffect(() => {
     if (isOpen) {
       document.addEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = 'hidden';
+      lockBodyScroll();
     }
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = 'unset';
+      // isOpen은 클로저에서 effect 실행 시점의 값을 캡처
+      // 모달이 열려 있었을 때만 스크롤 잠금 해제
+      if (isOpen) {
+        unlockBodyScroll();
+      }
     };
   }, [isOpen, handleKeyDown]);
 


### PR DESCRIPTION
## 🐛 Bug Fix

### 문제
여러 모달이 동시에 열려있을 때 하나가 닫히면 `document.body.style.overflow`가 무조건 `'unset'`으로 설정되어 다른 모달이 열려 있어도 배경 스크롤이 가능해지는 버그

### 원인
- Modal 컴포넌트의 useEffect cleanup 함수에서 열린 모달 수와 관계없이 무조건 스크롤 복원
- 다중 모달 사용 시나리오 미고려

### 해결 방법
- `openModalCount`를 통한 **reference counting** 방식 도입
- `lockBodyScroll()`: 첫 번째 모달 오픈 시에만 `overflow: hidden` 적용
- `unlockBodyScroll()`: 마지막 모달 닫힐 때에만 `overflow: unset` 복원
- `Math.max(0, ...)`로 카운터가 음수가 되는 edge case 방지

### 변경 파일
- `src/components/Modal/Modal.tsx`

### 테스트 방법
1. 첫 번째 모달 오픈 → 배경 스크롤 불가 확인
2. 첫 번째 모달에서 두 번째 모달 오픈 → 배경 스크롤 여전히 불가 확인
3. 두 번째 모달 닫기 → 배경 스크롤 여전히 불가 확인 (첫 번째 모달 열려있음)
4. 첫 번째 모달 닫기 → 배경 스크롤 가능 확인