### PR TITLE
[#14] 재무 추정 미리보기 (독립형) UI PoC

### DIFF
--- a/src/components/CTABanner.tsx
+++ b/src/components/CTABanner.tsx
@@ -1,0 +1,213 @@
+/**
+ * 파일명: CTABanner.tsx
+ * 
+ * 파일 용도:
+ * 로그인/회원가입 유도 배너 컴포넌트
+ * - 비로그인 사용자에게 프로젝트 저장 기능 안내
+ * - 로그인 페이지로 연결
+ * - 현재 입력값을 URL 파라미터로 전달
+ * 
+ * 디자인: 다크 모드 + 그라데이션 + 네온 액센트
+ */
+
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Sparkles, ArrowRight, Lock, Zap, Shield, Save } from 'lucide-react';
+import { Button } from './ui';
+import { cn } from '../lib/utils';
+
+interface CTABannerProps {
+  /** 배너 변형 */
+  variant?: 'default' | 'compact' | 'floating';
+  /** 현재 입력된 재무 데이터 (URL로 전달용) */
+  financialData?: {
+    customers?: number;
+    pricePerCustomer?: number;
+    cac?: number;
+    fixedCosts?: number;
+  };
+  /** 추가 클래스 */
+  className?: string;
+}
+
+/**
+ * CTABanner 컴포넌트
+ * 
+ * 역할:
+ * - 비로그인 사용자에게 로그인 유도
+ * - 재무 계산 결과를 프로젝트로 저장하도록 안내
+ * - 로그인 후 데이터 유지를 위한 URL 파라미터 전달
+ */
+export const CTABanner: React.FC<CTABannerProps> = ({
+  variant = 'default',
+  financialData,
+  className,
+}) => {
+  const navigate = useNavigate();
+
+  /**
+   * 로그인 페이지로 이동 (데이터 유지)
+   */
+  const handleLoginClick = () => {
+    // 재무 데이터를 URL 파라미터로 인코딩
+    const params = new URLSearchParams();
+    if (financialData) {
+      params.set('redirect', '/calculator');
+      if (financialData.customers) params.set('customers', financialData.customers.toString());
+      if (financialData.pricePerCustomer) params.set('arpu', financialData.pricePerCustomer.toString());
+      if (financialData.cac) params.set('cac', financialData.cac.toString());
+      if (financialData.fixedCosts) params.set('fixed', financialData.fixedCosts.toString());
+    }
+    
+    const queryString = params.toString();
+    navigate(`/login${queryString ? `?${queryString}` : ''}`);
+  };
+
+  /**
+   * 회원가입 페이지로 이동
+   */
+  const handleSignupClick = () => {
+    const params = new URLSearchParams();
+    if (financialData) {
+      params.set('redirect', '/calculator');
+    }
+    
+    const queryString = params.toString();
+    navigate(`/signup${queryString ? `?${queryString}` : ''}`);
+  };
+
+  // 플로팅 변형 (화면 하단 고정)
+  if (variant === 'floating') {
+    return (
+      <div className={cn(
+        'fixed bottom-0 left-0 right-0 z-40',
+        'bg-gradient-to-r from-slate-900/95 via-slate-800/95 to-slate-900/95',
+        'backdrop-blur-xl border-t border-white/10',
+        'px-4 py-4',
+        className
+      )}>
+        <div className="max-w-4xl mx-auto flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl bg-neon-500/20 flex items-center justify-center">
+              <Save className="w-5 h-5 text-neon-400" />
+            </div>
+            <div>
+              <p className="font-semibold text-white">이 설정을 저장하시겠어요?</p>
+              <p className="text-sm text-slate-400">로그인하면 프로젝트로 저장할 수 있습니다</p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={handleLoginClick}>
+              로그인
+            </Button>
+            <Button size="sm" onClick={handleSignupClick}>
+              무료로 시작
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 컴팩트 변형
+  if (variant === 'compact') {
+    return (
+      <div className={cn(
+        'glass-card p-4 flex items-center justify-between gap-4',
+        className
+      )}>
+        <div className="flex items-center gap-3">
+          <Lock className="w-5 h-5 text-slate-400" />
+          <p className="text-sm text-slate-300">
+            프로젝트로 저장하려면 <span className="text-neon-400 font-medium">로그인</span>이 필요합니다
+          </p>
+        </div>
+        <Button size="sm" onClick={handleLoginClick}>
+          로그인
+          <ArrowRight className="w-4 h-4 ml-1" />
+        </Button>
+      </div>
+    );
+  }
+
+  // 기본 변형
+  return (
+    <div className={cn(
+      'relative overflow-hidden rounded-2xl',
+      'bg-gradient-to-br from-slate-800 via-slate-900 to-slate-800',
+      'border border-white/10',
+      className
+    )}>
+      {/* 배경 효과 */}
+      <div className="absolute inset-0 bg-gradient-to-r from-neon-500/10 via-cyan-500/10 to-violet-500/10" />
+      <div className="absolute top-0 right-0 w-64 h-64 bg-neon-500/20 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" />
+      <div className="absolute bottom-0 left-0 w-64 h-64 bg-cyan-500/20 rounded-full blur-3xl translate-y-1/2 -translate-x-1/2" />
+      
+      <div className="relative p-8">
+        {/* 헤더 */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-neon-500 to-cyan-500 flex items-center justify-center shadow-neon">
+            <Sparkles className="w-6 h-6 text-slate-900" />
+          </div>
+          <div>
+            <h3 className="text-xl font-bold text-white">
+              이 설정으로 프로젝트를 시작하세요
+            </h3>
+            <p className="text-sm text-slate-400">
+              무료 회원가입으로 모든 기능을 이용할 수 있습니다
+            </p>
+          </div>
+        </div>
+
+        {/* 기능 목록 */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <div className="flex items-center gap-3 text-slate-300">
+            <div className="w-8 h-8 rounded-lg bg-neon-500/20 flex items-center justify-center flex-shrink-0">
+              <Save className="w-4 h-4 text-neon-400" />
+            </div>
+            <span className="text-sm">재무 데이터 저장</span>
+          </div>
+          <div className="flex items-center gap-3 text-slate-300">
+            <div className="w-8 h-8 rounded-lg bg-cyan-500/20 flex items-center justify-center flex-shrink-0">
+              <Zap className="w-4 h-4 text-cyan-400" />
+            </div>
+            <span className="text-sm">AI 사업계획서 생성</span>
+          </div>
+          <div className="flex items-center gap-3 text-slate-300">
+            <div className="w-8 h-8 rounded-lg bg-violet-500/20 flex items-center justify-center flex-shrink-0">
+              <Shield className="w-4 h-4 text-violet-400" />
+            </div>
+            <span className="text-sm">PDF/HWP 내보내기</span>
+          </div>
+        </div>
+
+        {/* CTA 버튼 */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Button 
+            size="lg" 
+            onClick={handleSignupClick}
+            className="flex-1 sm:flex-none"
+          >
+            무료로 시작하기
+            <ArrowRight className="w-5 h-5 ml-2" />
+          </Button>
+          <Button 
+            variant="outline" 
+            size="lg" 
+            onClick={handleLoginClick}
+            className="flex-1 sm:flex-none"
+          >
+            이미 계정이 있어요
+          </Button>
+        </div>
+
+        <p className="text-xs text-slate-500 mt-4 text-center sm:text-left">
+          가입 시 현재 입력한 재무 데이터가 자동으로 저장됩니다
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default CTABanner;
+

--- a/src/components/PreviewFinancialForm.tsx
+++ b/src/components/PreviewFinancialForm.tsx
@@ -1,0 +1,515 @@
+/**
+ * 파일명: PreviewFinancialForm.tsx
+ * 
+ * 파일 용도:
+ * 독립형 재무 계산기 폼 컴포넌트
+ * - 비로그인 사용자용 재무 입력 폼
+ * - 실시간 계산 및 결과 표시
+ * - 차트 시각화 (손익분기점, Unit Economics)
+ * 
+ * 호출 구조:
+ * PreviewFinancialForm (이 컴포넌트)
+ *   ├─> 입력 폼 (초기 자본, ARPU, CAC 등)
+ *   ├─> 핵심 지표 카드 (LTV, LTV/CAC, 손익분기점)
+ *   └─> Recharts 차트 (LineChart, BarChart)
+ * 
+ * 디자인: 다크 모드 + 글래스모피즘 + 네온 액센트
+ */
+
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { 
+  DollarSign, 
+  TrendingUp, 
+  Target, 
+  AlertCircle, 
+  CheckCircle2,
+  Users,
+  Percent,
+  Calculator
+} from 'lucide-react';
+import { Input, Badge } from './ui';
+import { formatCurrency, formatNumber, debounce } from '../lib/utils';
+import { cn } from '../lib/utils';
+
+/** 재무 입력 데이터 타입 */
+export interface FinancialInput {
+  initialCapital: number;      // 초기 자본
+  customers: number;           // 예상 고객 수
+  pricePerCustomer: number;    // 객단가 (ARPU)
+  cac: number;                 // 고객 획득 비용
+  fixedCosts: number;          // 고정비
+  variableCostRate: number;    // 변동비율 (%)
+  churnRate: number;           // 이탈률 (%)
+}
+
+/** 계산된 지표 타입 */
+interface FinancialMetrics {
+  revenue: number;
+  totalCosts: number;
+  profit: number;
+  ltv: number;
+  ltvCacRatio: number;
+  breakEvenPoint: number;
+  breakEvenMonth: number;
+}
+
+/** 차트 데이터 타입 */
+interface ChartDataPoint {
+  month: number;
+  revenue: number;
+  costs: number;
+  profit: number;
+  cumulativeProfit: number;
+}
+
+interface PreviewFinancialFormProps {
+  /** 입력값 변경 시 콜백 */
+  onInputChange?: (input: FinancialInput) => void;
+  /** 초기값 */
+  initialValues?: Partial<FinancialInput>;
+}
+
+// 기본값
+const DEFAULT_INPUT: FinancialInput = {
+  initialCapital: 50000000,
+  customers: 100,
+  pricePerCustomer: 50000,
+  cac: 30000,
+  fixedCosts: 5000000,
+  variableCostRate: 20,
+  churnRate: 5,
+};
+
+/**
+ * PreviewFinancialForm 컴포넌트
+ * 
+ * 역할:
+ * - 독립형 재무 계산기
+ * - 실시간 지표 계산
+ * - 시각화 차트 제공
+ */
+export const PreviewFinancialForm: React.FC<PreviewFinancialFormProps> = ({
+  onInputChange,
+  initialValues,
+}) => {
+  const [searchParams] = useSearchParams();
+  
+  // URL 파라미터에서 초기값 읽기
+  const getInitialInput = (): FinancialInput => {
+    const urlCustomers = searchParams.get('customers');
+    const urlArpu = searchParams.get('arpu');
+    const urlCac = searchParams.get('cac');
+    const urlFixed = searchParams.get('fixed');
+    
+    return {
+      ...DEFAULT_INPUT,
+      ...initialValues,
+      ...(urlCustomers && { customers: parseInt(urlCustomers) }),
+      ...(urlArpu && { pricePerCustomer: parseInt(urlArpu) }),
+      ...(urlCac && { cac: parseInt(urlCac) }),
+      ...(urlFixed && { fixedCosts: parseInt(urlFixed) }),
+    };
+  };
+
+  const [input, setInput] = useState<FinancialInput>(getInitialInput);
+
+  // 입력 변경 시 부모에게 알림 (debounce 적용)
+  const debouncedNotify = useMemo(
+    () => debounce((data: FinancialInput) => {
+      onInputChange?.(data);
+    }, 300),
+    [onInputChange]
+  );
+
+  useEffect(() => {
+    debouncedNotify(input);
+  }, [input, debouncedNotify]);
+
+  /**
+   * 입력 핸들러
+   */
+  const handleInputChange = useCallback((field: keyof FinancialInput, value: number) => {
+    setInput(prev => ({ ...prev, [field]: value }));
+  }, []);
+
+  /**
+   * 재무 지표 계산
+   */
+  const metrics: FinancialMetrics = useMemo(() => {
+    const { customers, pricePerCustomer, cac, fixedCosts, variableCostRate, churnRate } = input;
+    
+    // 월 매출
+    const revenue = customers * pricePerCustomer;
+    
+    // 총 비용 (고정비 + 변동비 + 신규 고객 획득 비용)
+    const variableCosts = revenue * (variableCostRate / 100);
+    const acquisitionCosts = customers * cac * (churnRate / 100); // 이탈 고객 대체 비용
+    const totalCosts = fixedCosts + variableCosts + acquisitionCosts;
+    
+    // 순이익
+    const profit = revenue - totalCosts;
+    
+    // LTV 계산 (이탈률이 0이면 무한대 방지)
+    const effectiveChurnRate = Math.max(churnRate, 1) / 100;
+    const ltv = pricePerCustomer * (1 - variableCostRate / 100) / effectiveChurnRate;
+    
+    // LTV/CAC 비율
+    const ltvCacRatio = cac > 0 ? ltv / cac : 0;
+    
+    // 손익분기점 고객 수
+    const contributionMargin = pricePerCustomer * (1 - variableCostRate / 100) - cac * (churnRate / 100);
+    const breakEvenPoint = contributionMargin > 0 ? Math.ceil(fixedCosts / contributionMargin) : 0;
+    
+    // 손익분기점 도달 월
+    const monthlyProfit = profit;
+    const breakEvenMonth = monthlyProfit > 0 
+      ? Math.ceil(input.initialCapital > 0 ? 1 : fixedCosts / monthlyProfit)
+      : 0;
+
+    return {
+      revenue,
+      totalCosts,
+      profit,
+      ltv,
+      ltvCacRatio,
+      breakEvenPoint,
+      breakEvenMonth,
+    };
+  }, [input]);
+
+  /**
+   * 12개월 차트 데이터 생성
+   */
+  const chartData: ChartDataPoint[] = useMemo(() => {
+    const data: ChartDataPoint[] = [];
+    let cumulativeProfit = -input.initialCapital; // 초기 투자금 반영
+    
+    for (let month = 1; month <= 12; month++) {
+      // 고객 성장률 가정 (월 10% 성장)
+      const growthRate = 1 + (0.1 * (month - 1));
+      const monthlyCustomers = Math.floor(input.customers * growthRate);
+      
+      const revenue = monthlyCustomers * input.pricePerCustomer;
+      const variableCosts = revenue * (input.variableCostRate / 100);
+      const acquisitionCosts = monthlyCustomers * input.cac * (input.churnRate / 100);
+      const costs = input.fixedCosts + variableCosts + acquisitionCosts;
+      const profit = revenue - costs;
+      
+      cumulativeProfit += profit;
+      
+      data.push({
+        month,
+        revenue,
+        costs,
+        profit,
+        cumulativeProfit,
+      });
+    }
+    
+    return data;
+  }, [input]);
+
+  // LTV/CAC 경고 여부
+  const ltvCacWarning = metrics.ltvCacRatio < 3;
+
+  return (
+    <div className="space-y-8">
+      {/* 입력 섹션 */}
+      <div className="glass-card p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-10 h-10 rounded-xl bg-cyan-500/20 flex items-center justify-center">
+            <Calculator className="w-5 h-5 text-cyan-400" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-white">재무 가정 입력</h3>
+            <p className="text-sm text-slate-400">핵심 변수를 입력하면 자동으로 계산됩니다</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-300">
+              <DollarSign className="w-4 h-4 text-neon-400" />
+              초기 자본 (원)
+            </label>
+            <Input
+              type="number"
+              value={input.initialCapital}
+              onChange={(e) => handleInputChange('initialCapital', parseInt(e.target.value) || 0)}
+              helperText="사업 시작 자본금"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-300">
+              <Users className="w-4 h-4 text-cyan-400" />
+              예상 고객 수
+            </label>
+            <Input
+              type="number"
+              value={input.customers}
+              onChange={(e) => handleInputChange('customers', parseInt(e.target.value) || 0)}
+              helperText="월간 예상 고객 수"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-300">
+              <DollarSign className="w-4 h-4 text-violet-400" />
+              객단가 (원)
+            </label>
+            <Input
+              type="number"
+              value={input.pricePerCustomer}
+              onChange={(e) => handleInputChange('pricePerCustomer', parseInt(e.target.value) || 0)}
+              helperText="고객 1인당 월 평균 매출 (ARPU)"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-300">
+              <Target className="w-4 h-4 text-amber-400" />
+              CAC (원)
+            </label>
+            <Input
+              type="number"
+              value={input.cac}
+              onChange={(e) => handleInputChange('cac', parseInt(e.target.value) || 0)}
+              helperText="고객 획득 비용"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-300">
+              <DollarSign className="w-4 h-4 text-red-400" />
+              고정비 (원)
+            </label>
+            <Input
+              type="number"
+              value={input.fixedCosts}
+              onChange={(e) => handleInputChange('fixedCosts', parseInt(e.target.value) || 0)}
+              helperText="월간 고정 비용"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-300">
+              <Percent className="w-4 h-4 text-slate-400" />
+              변동비율 / 이탈률 (%)
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                type="number"
+                value={input.variableCostRate}
+                onChange={(e) => handleInputChange('variableCostRate', parseInt(e.target.value) || 0)}
+                helperText="변동비"
+              />
+              <Input
+                type="number"
+                value={input.churnRate}
+                onChange={(e) => handleInputChange('churnRate', parseInt(e.target.value) || 0)}
+                helperText="이탈률"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 핵심 지표 */}
+      <div className="glass-card p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl bg-neon-500/20 flex items-center justify-center">
+              <TrendingUp className="w-5 h-5 text-neon-400" />
+            </div>
+            <h3 className="text-lg font-semibold text-white">핵심 지표</h3>
+          </div>
+          <Badge variant={ltvCacWarning ? 'warning' : 'success'}>
+            {ltvCacWarning ? (
+              <>
+                <AlertCircle className="w-3 h-3 mr-1" />
+                개선 필요
+              </>
+            ) : (
+              <>
+                <CheckCircle2 className="w-3 h-3 mr-1" />
+                건강한 지표
+              </>
+            )}
+          </Badge>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="glass-card-hover p-4">
+            <div className="flex items-center gap-2 text-cyan-400 mb-2">
+              <DollarSign className="w-4 h-4" />
+              <span className="text-sm font-medium">월 매출</span>
+            </div>
+            <div className="text-2xl font-bold text-white">
+              {formatCurrency(metrics.revenue)}
+            </div>
+          </div>
+
+          <div className="glass-card-hover p-4">
+            <div className="flex items-center gap-2 text-neon-400 mb-2">
+              <TrendingUp className="w-4 h-4" />
+              <span className="text-sm font-medium">LTV</span>
+            </div>
+            <div className="text-2xl font-bold text-white">
+              {formatCurrency(metrics.ltv)}
+            </div>
+          </div>
+
+          <div className={cn(
+            'glass-card-hover p-4',
+            ltvCacWarning && 'border-red-500/30'
+          )}>
+            <div className={cn(
+              'flex items-center gap-2 mb-2',
+              ltvCacWarning ? 'text-red-400' : 'text-neon-400'
+            )}>
+              <Target className="w-4 h-4" />
+              <span className="text-sm font-medium">LTV/CAC</span>
+            </div>
+            <div className={cn(
+              'text-2xl font-bold',
+              ltvCacWarning ? 'text-red-400' : 'text-white'
+            )}>
+              {metrics.ltvCacRatio.toFixed(1)}x
+            </div>
+          </div>
+
+          <div className="glass-card-hover p-4">
+            <div className="flex items-center gap-2 text-violet-400 mb-2">
+              <Target className="w-4 h-4" />
+              <span className="text-sm font-medium">손익분기점</span>
+            </div>
+            <div className="text-2xl font-bold text-white">
+              {formatNumber(metrics.breakEvenPoint)}명
+            </div>
+          </div>
+        </div>
+
+        {/* LTV/CAC 경고 */}
+        {ltvCacWarning && (
+          <div className="mt-4 bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
+            <div>
+              <div className="font-semibold text-red-400 mb-1">수익성 경고</div>
+              <p className="text-sm text-slate-400">
+                LTV/CAC 비율이 3 미만입니다. 고객 획득 비용을 낮추거나 고객 생애가치를 높이는 전략이 필요합니다.
+                건강한 비즈니스 모델은 일반적으로 3 이상의 비율을 유지합니다.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 손익분기점 차트 */}
+      <div className="glass-card p-6">
+        <h3 className="text-lg font-semibold text-white mb-6">손익분기점 분석 (12개월)</h3>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+            <XAxis 
+              dataKey="month" 
+              stroke="rgba(255,255,255,0.5)"
+              tick={{ fill: 'rgba(255,255,255,0.5)' }}
+            />
+            <YAxis 
+              tickFormatter={(value) => `${(value / 1000000).toFixed(0)}M`}
+              stroke="rgba(255,255,255,0.5)"
+              tick={{ fill: 'rgba(255,255,255,0.5)' }}
+            />
+            <Tooltip 
+              contentStyle={{ 
+                backgroundColor: 'rgba(15, 23, 42, 0.95)', 
+                border: '1px solid rgba(255,255,255,0.1)',
+                borderRadius: '8px',
+              }}
+              labelStyle={{ color: '#fff' }}
+              formatter={(value: number) => formatCurrency(value)}
+              labelFormatter={(label) => `${label}개월차`}
+            />
+            <Legend />
+            <Line 
+              type="monotone" 
+              dataKey="revenue" 
+              stroke="#22d3ee" 
+              name="매출" 
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line 
+              type="monotone" 
+              dataKey="costs" 
+              stroke="#f87171" 
+              name="비용" 
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line 
+              type="monotone" 
+              dataKey="profit" 
+              stroke="#4ade80" 
+              name="이익" 
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Unit Economics 차트 */}
+      <div className="glass-card p-6">
+        <h3 className="text-lg font-semibold text-white mb-6">Unit Economics</h3>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={[
+            { name: 'LTV', value: metrics.ltv, fill: '#4ade80' },
+            { name: 'CAC', value: input.cac, fill: '#f87171' },
+          ]}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+            <XAxis 
+              dataKey="name"
+              stroke="rgba(255,255,255,0.5)"
+              tick={{ fill: 'rgba(255,255,255,0.5)' }}
+            />
+            <YAxis 
+              tickFormatter={(value) => `${(value / 1000).toFixed(0)}K`}
+              stroke="rgba(255,255,255,0.5)"
+              tick={{ fill: 'rgba(255,255,255,0.5)' }}
+            />
+            <Tooltip 
+              contentStyle={{ 
+                backgroundColor: 'rgba(15, 23, 42, 0.95)', 
+                border: '1px solid rgba(255,255,255,0.1)',
+                borderRadius: '8px',
+              }}
+              formatter={(value: number) => formatCurrency(value)}
+            />
+            <Bar dataKey="value" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+        <p className="text-sm text-slate-500 mt-4 text-center">
+          이상적인 비율: LTV ≥ 3 × CAC
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PreviewFinancialForm;
+

--- a/src/pages/FinancialCalculatorPage.tsx
+++ b/src/pages/FinancialCalculatorPage.tsx
@@ -1,0 +1,243 @@
+/**
+ * 파일명: FinancialCalculatorPage.tsx
+ * 
+ * 파일 용도:
+ * 독립형 재무 계산기 페이지 (Public Route)
+ * - 비로그인 사용자도 접근 가능
+ * - 재무 시뮬레이션 미리보기
+ * - 로그인 유도 CTA 배너
+ * 
+ * 라우트: /calculator
+ * 
+ * 호출 구조:
+ * FinancialCalculatorPage (이 컴포넌트)
+ *   ├─> PreviewFinancialForm - 재무 입력 폼 및 차트
+ *   ├─> CTABanner - 로그인 유도 배너
+ *   └─> useAuthStore - 로그인 상태 확인
+ * 
+ * 디자인: 다크 모드 + 글래스모피즘 + 네온 액센트
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { Calculator, ArrowLeft, Sparkles, TrendingUp, Shield, Zap } from 'lucide-react';
+import { PreviewFinancialForm, FinancialInput } from '../components/PreviewFinancialForm';
+import { CTABanner } from '../components/CTABanner';
+import { useAuthStore } from '../stores/useAuthStore';
+import { Button } from '../components/ui';
+import { cn } from '../lib/utils';
+
+/**
+ * FinancialCalculatorPage 컴포넌트
+ * 
+ * 역할:
+ * - 독립형 재무 계산기 페이지
+ * - 비로그인 사용자 접근 가능
+ * - 로그인 시 프로젝트 저장 유도
+ */
+export const FinancialCalculatorPage: React.FC = () => {
+  const { isAuthenticated } = useAuthStore();
+  const [financialData, setFinancialData] = useState<Partial<FinancialInput>>({});
+
+  /**
+   * 재무 데이터 변경 핸들러
+   */
+  const handleInputChange = useCallback((input: FinancialInput) => {
+    setFinancialData(input);
+  }, []);
+
+  return (
+    <div className="min-h-screen py-8 px-4">
+      <div className="max-w-6xl mx-auto">
+        {/* 헤더 */}
+        <div className="mb-8">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 text-slate-400 hover:text-white transition-colors mb-6"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            홈으로 돌아가기
+          </Link>
+
+          <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
+            <div className="flex items-start gap-4">
+              <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-cyan-500 to-neon-500 flex items-center justify-center shadow-neon-lg flex-shrink-0">
+                <Calculator className="w-8 h-8 text-slate-900" />
+              </div>
+              <div>
+                <h1 className="text-3xl font-bold text-white mb-2">
+                  재무 추정 계산기
+                </h1>
+                <p className="text-slate-400 max-w-xl">
+                  핵심 비즈니스 변수를 입력하면 손익분기점, LTV/CAC 비율 등 
+                  주요 재무 지표를 실시간으로 확인할 수 있습니다.
+                </p>
+              </div>
+            </div>
+
+            {/* 로그인된 경우 프로젝트 생성 버튼 */}
+            {isAuthenticated && (
+              <Link to="/">
+                <Button size="lg">
+                  <Sparkles className="w-5 h-5 mr-2" />
+                  프로젝트로 저장하기
+                </Button>
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* 기능 소개 (비로그인 시) */}
+        {!isAuthenticated && (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+            <FeatureCard
+              icon={<TrendingUp className="w-5 h-5" />}
+              title="실시간 시뮬레이션"
+              description="값을 변경하면 즉시 결과가 업데이트됩니다"
+              color="cyan"
+            />
+            <FeatureCard
+              icon={<Zap className="w-5 h-5" />}
+              title="즉시 사용 가능"
+              description="회원가입 없이 바로 계산해볼 수 있습니다"
+              color="neon"
+            />
+            <FeatureCard
+              icon={<Shield className="w-5 h-5" />}
+              title="프로젝트 저장"
+              description="로그인하면 결과를 저장하고 공유할 수 있습니다"
+              color="violet"
+            />
+          </div>
+        )}
+
+        {/* 메인 컨텐츠 */}
+        <div className="lg:grid lg:grid-cols-3 lg:gap-8">
+          {/* 계산기 폼 (2/3) */}
+          <div className="lg:col-span-2">
+            <PreviewFinancialForm onInputChange={handleInputChange} />
+          </div>
+
+          {/* 사이드바 (1/3) */}
+          <div className="mt-8 lg:mt-0 space-y-6">
+            {/* CTA 배너 (비로그인 시) */}
+            {!isAuthenticated && (
+              <CTABanner 
+                variant="default" 
+                financialData={{
+                  customers: financialData.customers,
+                  pricePerCustomer: financialData.pricePerCustomer,
+                  cac: financialData.cac,
+                  fixedCosts: financialData.fixedCosts,
+                }}
+              />
+            )}
+
+            {/* 도움말 */}
+            <div className="glass-card p-6">
+              <h3 className="text-lg font-semibold text-white mb-4">💡 가이드</h3>
+              <div className="space-y-4 text-sm text-slate-400">
+                <div>
+                  <p className="font-medium text-slate-300 mb-1">LTV/CAC 비율</p>
+                  <p>3 이상이면 건강한 비즈니스 모델입니다. 1 미만이면 고객 획득에 손실이 발생합니다.</p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-300 mb-1">손익분기점</p>
+                  <p>이익이 0이 되는 최소 고객 수입니다. 이 숫자보다 많은 고객을 확보해야 수익이 발생합니다.</p>
+                </div>
+                <div>
+                  <p className="font-medium text-slate-300 mb-1">이탈률</p>
+                  <p>매월 서비스를 떠나는 고객의 비율입니다. 5% 이하를 목표로 하세요.</p>
+                </div>
+              </div>
+            </div>
+
+            {/* FAQ */}
+            <div className="glass-card p-6">
+              <h3 className="text-lg font-semibold text-white mb-4">자주 묻는 질문</h3>
+              <div className="space-y-4">
+                <FAQItem
+                  question="계산 결과가 저장되나요?"
+                  answer="비로그인 상태에서는 저장되지 않습니다. 로그인하면 프로젝트로 저장할 수 있습니다."
+                />
+                <FAQItem
+                  question="어떤 데이터가 필요한가요?"
+                  answer="예상 고객 수, 객단가, 고객 획득 비용, 고정비, 변동비율, 이탈률이 필요합니다."
+                />
+                <FAQItem
+                  question="결과를 공유할 수 있나요?"
+                  answer="로그인 후 프로젝트로 저장하면 PDF나 링크로 공유할 수 있습니다."
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 플로팅 CTA (비로그인 시, 모바일용) */}
+        {!isAuthenticated && (
+          <div className="lg:hidden">
+            <CTABanner 
+              variant="floating" 
+              financialData={{
+                customers: financialData.customers,
+                pricePerCustomer: financialData.pricePerCustomer,
+                cac: financialData.cac,
+                fixedCosts: financialData.fixedCosts,
+              }}
+            />
+            {/* 플로팅 배너 높이만큼 여백 추가 */}
+            <div className="h-24" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * 기능 카드 컴포넌트
+ */
+interface FeatureCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  color: 'cyan' | 'neon' | 'violet';
+}
+
+const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description, color }) => {
+  const colorStyles = {
+    cyan: 'bg-cyan-500/20 text-cyan-400',
+    neon: 'bg-neon-500/20 text-neon-400',
+    violet: 'bg-violet-500/20 text-violet-400',
+  };
+
+  return (
+    <div className="glass-card p-4 flex items-start gap-3">
+      <div className={cn('w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0', colorStyles[color])}>
+        {icon}
+      </div>
+      <div>
+        <h4 className="font-medium text-white mb-1">{title}</h4>
+        <p className="text-sm text-slate-400">{description}</p>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * FAQ 아이템 컴포넌트
+ */
+interface FAQItemProps {
+  question: string;
+  answer: string;
+}
+
+const FAQItem: React.FC<FAQItemProps> = ({ question, answer }) => (
+  <div>
+    <p className="font-medium text-slate-300 mb-1">{question}</p>
+    <p className="text-sm text-slate-400">{answer}</p>
+  </div>
+);
+
+export default FinancialCalculatorPage;
+

--- a/src/router/AppRoutes.tsx
+++ b/src/router/AppRoutes.tsx
@@ -61,6 +61,9 @@ const NotFoundPage = lazy(() => import('../pages/NotFoundPage'));
 /** 프로필 페이지 */
 const ProfilePage = lazy(() => import('../pages/ProfilePage'));
 
+/** 재무 계산기 페이지 (Public) */
+const FinancialCalculatorPage = lazy(() => import('../pages/FinancialCalculatorPage'));
+
 /**
  * SuspenseWrapper 컴포넌트
  * 
@@ -123,6 +126,16 @@ export const AppRoutes: React.FC = () => {
         element={
           <SuspenseWrapper>
             <ProfilePage />
+          </SuspenseWrapper>
+        }
+      />
+
+      {/* 재무 계산기 페이지 (Public, 비로그인도 접근 가능) */}
+      <Route
+        path="/calculator"
+        element={
+          <SuspenseWrapper>
+            <FinancialCalculatorPage />
           </SuspenseWrapper>
         }
       />


### PR DESCRIPTION
## 📋 Summary

비로그인 사용자도 접근 가능한 독립형 재무 계산기를 구현하고, 계산 결과를 프로젝트로 연결하는 전환 흐름을 제공합니다.

## 🔧 Changes

### 신규 파일

#### `src/components/CTABanner.tsx`
- 로그인 유도 배너 (3가지 변형)
  - `default`: 전체 기능 소개 + CTA
  - `compact`: 간단한 인라인 배너
  - `floating`: 모바일용 하단 고정
- 재무 데이터 URL 파라미터 전달

#### `src/components/PreviewFinancialForm.tsx`
- 독립형 재무 입력 폼 (7개 필드)
- 실시간 지표 계산 (LTV, LTV/CAC, 손익분기점)
- 12개월 손익분기점 차트 (Recharts)
- Unit Economics 바 차트
- LTV/CAC 경고 표시
- 다크 테마 스타일

#### `src/pages/FinancialCalculatorPage.tsx`
- Public Route 계산기 페이지
- 비로그인 접근 가능
- 기능 소개 카드 (비로그인 시)
- FAQ 및 가이드 사이드바
- 반응형 레이아웃

### 수정된 파일

#### `src/router/AppRoutes.tsx`
- `/calculator` 라우트 추가
- Lazy loading 적용

## ✅ Checklist

- [x] FinancialCalculatorPage 컴포넌트 (Public Route)
- [x] PreviewFinancialForm 컴포넌트
- [x] EPIC0-FE-004 차트 컴포넌트 재사용
- [x] CTABanner 컴포넌트 (로그인 유도)
- [x] URL 파라미터로 초기값 전달
- [ ] FinancialPreviewController API 연동 (백엔드 구현 후)

## 🎨 UI Features

| 기능 | 설명 |
|------|------|
| 재무 계산기 | 7개 변수 입력, 실시간 계산 |
| 차트 시각화 | 손익분기점, Unit Economics |
| CTA 배너 | 로그인 유도 (3가지 변형) |
| 디자인 | 다크 모드 + 글래스모피즘 |

## 📁 File Structure

```
src/
├── components/
│   ├── CTABanner.tsx            (NEW)
│   └── PreviewFinancialForm.tsx (NEW)
├── pages/
│   └── FinancialCalculatorPage.tsx (NEW)
└── router/
    └── AppRoutes.tsx            (UPDATED)
```

## 🔗 Related Issues

Closes #14

## 📊 Build Result

```
FinancialCalculatorPage-SBVU6SS7.js   19.92 kB │ gzip: 5.57 kB
✓ built in 2.89s
```