### PR TITLE
feat: Mock 데이터를 실제 API 호출로 교체

### DIFF
--- a/src/pages/ProjectCreate.tsx
+++ b/src/pages/ProjectCreate.tsx
@@ -6,15 +6,18 @@
  * - 사용자로부터 프로젝트명과 템플릿 선택을 받음
  * - 프로젝트 생성 후 마법사 단계로 이동
  * 
+ * API 연동:
+ * - projectService.getTemplates() 로 템플릿 목록 조회
+ * - projectService.createProject() 로 프로젝트 생성
+ * 
  * 디자인: 다크 모드 + 글래스모피즘 + 네온 액센트
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useProjectStore } from '@/stores/useProjectStore';
 import { useWizardStore } from '@/stores/useWizardStore';
-import { templates } from '@/types/mockData';
-import { TemplateType } from '@/types';
+import { templates as fallbackTemplates } from '@/types/mockData';
 import { 
   Rocket, 
   Sparkles, 
@@ -24,7 +27,8 @@ import {
   Check,
   Zap,
   BarChart3,
-  FileText
+  FileText,
+  Loader2
 } from 'lucide-react';
 import { cn } from '@/common/utils';
 
@@ -34,18 +38,77 @@ import { cn } from '@/common/utils';
  */
 export const ProjectCreate: React.FC = () => {
   const navigate = useNavigate();
-  const { createProject } = useProjectStore();
-  const { resetWizard } = useWizardStore();
+  const { 
+    templates, 
+    fetchTemplates, 
+    createProject, 
+    isLoading: isCreating,
+    error: storeError 
+  } = useProjectStore();
+  const { resetWizard, setProjectId } = useWizardStore();
 
   const [projectName, setProjectName] = useState('');
-  const [selectedTemplate, setSelectedTemplate] = useState<TemplateType | null>(null);
+  const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
   const [error, setError] = useState('');
   const [isHovered, setIsHovered] = useState<string | null>(null);
+  const [isLoadingTemplates, setIsLoadingTemplates] = useState(true);
+
+  // 템플릿 목록을 API 또는 fallback에서 가져옴
+  const displayTemplates = templates.length > 0 
+    ? templates.map(t => ({
+        id: t.code,
+        name: t.name,
+        description: t.description,
+        icon: getTemplateIcon(t.code),
+        features: getTemplateFeatures(t.category),
+      }))
+    : fallbackTemplates;
+
+  /**
+   * 템플릿 아이콘 반환
+   */
+  function getTemplateIcon(code: string): string {
+    const icons: Record<string, string> = {
+      'pre-startup': '🚀',
+      'early-startup': '💼',
+      'bank-loan': '🏦',
+    };
+    return icons[code] || '📄';
+  }
+
+  /**
+   * 템플릿 특징 반환
+   */
+  function getTemplateFeatures(category: string): string[] {
+    const features: Record<string, string[]> = {
+      'government': ['정부지원 양식 호환', 'PMF 검증 전략', '상세 재무 분석', '투자 유치 준비'],
+      'bank': ['담보/신용 분석', '상환 계획 수립', '리스크 관리', '보수적 재무 예측'],
+      'investor': ['아이디어 검증 중심', 'MVP 구축 계획', '초기 시장 조사', '기본 재무 설계'],
+    };
+    return features[category] || features['government'];
+  }
+
+  /**
+   * 컴포넌트 마운트 시 템플릿 목록 조회
+   */
+  useEffect(() => {
+    const loadTemplates = async () => {
+      setIsLoadingTemplates(true);
+      try {
+        await fetchTemplates();
+      } catch (err) {
+        console.warn('Failed to fetch templates from API, using fallback:', err);
+      } finally {
+        setIsLoadingTemplates(false);
+      }
+    };
+    loadTemplates();
+  }, [fetchTemplates]);
 
   /**
    * 폼 제출 핸들러
    */
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
     if (!projectName.trim()) {
@@ -58,12 +121,21 @@ export const ProjectCreate: React.FC = () => {
       return;
     }
 
-    createProject(projectName, selectedTemplate);
-    resetWizard();
-    navigate('/wizard/1');
+    try {
+      // API로 프로젝트 생성
+      const project = await createProject(projectName, selectedTemplate);
+      
+      // 위저드 초기화 및 프로젝트 ID 설정
+      resetWizard();
+      setProjectId(project.id);
+      
+      navigate('/wizard/1');
+    } catch (err) {
+      setError(storeError || '프로젝트 생성에 실패했습니다.');
+    }
   };
 
-  // 템플릿 아이콘 매핑 (mockData.ts의 ID와 일치)
+  // 템플릿 아이콘 매핑
   const templateIcons: Record<string, React.ReactNode> = {
     'pre-startup': <Rocket className="w-8 h-8" />,
     'early-startup': <TrendingUp className="w-8 h-8" />,
@@ -162,85 +234,92 @@ export const ProjectCreate: React.FC = () => {
                 <h2 className="text-lg sm:text-xl font-semibold text-white">템플릿 선택</h2>
               </div>
 
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 lg:gap-5">
-                {templates.map((template) => {
-                  const isSelected = selectedTemplate === template.id;
-                  const colors = templateColors[template.id] || templateColors['pre-startup'];
-                  
-                  return (
-                    <button
-                      key={template.id}
-                      type="button"
-                      className={cn(
-                        'relative p-4 sm:p-5 lg:p-6 rounded-xl text-left transition-all duration-300',
-                        'bg-gradient-to-br border',
-                        colors.bg,
-                        isSelected 
-                          ? `${colors.border} ${colors.glow}` 
-                          : 'border-white/10 hover:border-white/20',
-                        isSelected && 'scale-[1.02]',
-                        isHovered === template.id && !isSelected && 'scale-[1.01] shadow-lg',
-                        'group'
-                      )}
-                      onClick={() => {
-                        setSelectedTemplate(template.id);
-                        setError('');
-                      }}
-                      onMouseEnter={() => setIsHovered(template.id)}
-                      onMouseLeave={() => setIsHovered(null)}
-                    >
-                      {/* 선택 체크마크 */}
-                      {isSelected && (
-                        <div className="absolute top-3 right-3 sm:top-4 sm:right-4 w-5 h-5 sm:w-6 sm:h-6 rounded-full bg-neon-500 flex items-center justify-center animate-scale-in">
-                          <Check className="w-3 h-3 sm:w-4 sm:h-4 text-slate-900" />
+              {isLoadingTemplates ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="w-8 h-8 text-neon-400 animate-spin" />
+                  <span className="ml-3 text-slate-400">템플릿 로딩 중...</span>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 lg:gap-5">
+                  {displayTemplates.map((template) => {
+                    const isSelected = selectedTemplate === template.id;
+                    const colors = templateColors[template.id] || templateColors['pre-startup'];
+                    
+                    return (
+                      <button
+                        key={template.id}
+                        type="button"
+                        className={cn(
+                          'relative p-4 sm:p-5 lg:p-6 rounded-xl text-left transition-all duration-300',
+                          'bg-gradient-to-br border',
+                          colors.bg,
+                          isSelected 
+                            ? `${colors.border} ${colors.glow}` 
+                            : 'border-white/10 hover:border-white/20',
+                          isSelected && 'scale-[1.02]',
+                          isHovered === template.id && !isSelected && 'scale-[1.01] shadow-lg',
+                          'group'
+                        )}
+                        onClick={() => {
+                          setSelectedTemplate(template.id);
+                          setError('');
+                        }}
+                        onMouseEnter={() => setIsHovered(template.id)}
+                        onMouseLeave={() => setIsHovered(null)}
+                      >
+                        {/* 선택 체크마크 */}
+                        {isSelected && (
+                          <div className="absolute top-3 right-3 sm:top-4 sm:right-4 w-5 h-5 sm:w-6 sm:h-6 rounded-full bg-neon-500 flex items-center justify-center animate-scale-in">
+                            <Check className="w-3 h-3 sm:w-4 sm:h-4 text-slate-900" />
+                          </div>
+                        )}
+
+                        {/* 아이콘 - 반응형 */}
+                        <div className={cn(
+                          'w-10 h-10 sm:w-12 sm:h-12 lg:w-14 lg:h-14 rounded-lg sm:rounded-xl mb-3 sm:mb-4 flex items-center justify-center transition-all duration-300',
+                          isSelected 
+                            ? 'bg-white/20 text-white' 
+                            : 'bg-white/5 text-slate-400 group-hover:bg-white/10 group-hover:text-white'
+                        )}>
+                          {templateIcons[template.id] || <FileText className="w-8 h-8" />}
                         </div>
-                      )}
 
-                      {/* 아이콘 - 반응형 */}
-                      <div className={cn(
-                        'w-10 h-10 sm:w-12 sm:h-12 lg:w-14 lg:h-14 rounded-lg sm:rounded-xl mb-3 sm:mb-4 flex items-center justify-center transition-all duration-300',
-                        isSelected 
-                          ? 'bg-white/20 text-white' 
-                          : 'bg-white/5 text-slate-400 group-hover:bg-white/10 group-hover:text-white'
-                      )}>
-                        {templateIcons[template.id]}
-                      </div>
+                        {/* 템플릿 정보 - 반응형 */}
+                        <h3 className={cn(
+                          'text-base sm:text-lg font-semibold mb-1 sm:mb-2 transition-colors',
+                          isSelected ? 'text-white' : 'text-slate-200'
+                        )}>
+                          {template.name}
+                        </h3>
+                        
+                        <p className="text-xs sm:text-sm text-slate-400 mb-3 sm:mb-4 line-clamp-2">
+                          {template.description}
+                        </p>
 
-                      {/* 템플릿 정보 - 반응형 */}
-                      <h3 className={cn(
-                        'text-base sm:text-lg font-semibold mb-1 sm:mb-2 transition-colors',
-                        isSelected ? 'text-white' : 'text-slate-200'
-                      )}>
-                        {template.name}
-                      </h3>
-                      
-                      <p className="text-xs sm:text-sm text-slate-400 mb-3 sm:mb-4 line-clamp-2">
-                        {template.description}
-                      </p>
-
-                      {/* 특징 목록 */}
-                      <ul className="space-y-2">
-                        {template.features.slice(0, 3).map((feature, index) => (
-                          <li 
-                            key={index} 
-                            className="flex items-start gap-2 text-xs text-slate-500"
-                          >
-                            <span className={cn(
-                              'mt-0.5 transition-colors',
-                              isSelected ? 'text-neon-400' : 'text-slate-600'
-                            )}>
-                              ✦
-                            </span>
-                            <span className={isSelected ? 'text-slate-300' : ''}>
-                              {feature}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    </button>
-                  );
-                })}
-              </div>
+                        {/* 특징 목록 */}
+                        <ul className="space-y-2">
+                          {template.features.slice(0, 3).map((feature, index) => (
+                            <li 
+                              key={index} 
+                              className="flex items-start gap-2 text-xs text-slate-500"
+                            >
+                              <span className={cn(
+                                'mt-0.5 transition-colors',
+                                isSelected ? 'text-neon-400' : 'text-slate-600'
+                              )}>
+                                ✦
+                              </span>
+                              <span className={isSelected ? 'text-slate-300' : ''}>
+                                {feature}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
 
             {/* 에러 메시지 */}
@@ -257,10 +336,20 @@ export const ProjectCreate: React.FC = () => {
             <div className="flex justify-center pt-4 animate-slide-up delay-200">
               <button
                 type="submit"
-                className="btn-neon group flex items-center gap-3 text-lg"
+                disabled={isCreating}
+                className="btn-neon group flex items-center gap-3 text-lg disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <span>사업계획서 작성 시작</span>
-                <ArrowRight className="w-5 h-5 transition-transform group-hover:translate-x-1" />
+                {isCreating ? (
+                  <>
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                    <span>프로젝트 생성 중...</span>
+                  </>
+                ) : (
+                  <>
+                    <span>사업계획서 작성 시작</span>
+                    <ArrowRight className="w-5 h-5 transition-transform group-hover:translate-x-1" />
+                  </>
+                )}
               </button>
             </div>
           </form>

--- a/src/pages/ProjectCreate.tsx
+++ b/src/pages/ProjectCreate.tsx
@@ -130,7 +130,7 @@ export const ProjectCreate: React.FC = () => {
       setProjectId(project.id);
       
       navigate('/wizard/1');
-    } catch (err) {
+    } catch {
       setError(storeError || '프로젝트 생성에 실패했습니다.');
     }
   };

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -117,7 +117,7 @@ export const SignupPage: React.FC = () => {
       await signup({
         email: data.email,
         password: data.password,
-        displayName: data.displayName,
+        name: data.displayName,
       });
       toast.success('회원가입이 완료되었습니다.\n로그인해주세요.');
       navigate('/login');

--- a/src/pages/profile/ProfileEditForm.tsx
+++ b/src/pages/profile/ProfileEditForm.tsx
@@ -51,14 +51,14 @@ export const ProfileEditForm: React.FC = () => {
   } = useForm<ProfileFormData>({
     resolver: zodResolver(profileSchema),
     defaultValues: {
-      displayName: user?.displayName || '',
+      displayName: user?.name || '',
     },
   });
 
   // 사용자 정보 변경 시 폼 리셋
   useEffect(() => {
     if (user) {
-      reset({ displayName: user.displayName || '' });
+      reset({ displayName: user.name || '' });
     }
   }, [user, reset]);
 
@@ -76,7 +76,7 @@ export const ProfileEditForm: React.FC = () => {
       if (user) {
         setUser({
           ...user,
-          displayName: data.displayName,
+          name: data.displayName,
         });
       }
 

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -100,7 +100,7 @@ export const ProfilePage: React.FC = () => {
             <div className="relative">
               <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-neon-500 to-cyan-500 flex items-center justify-center shadow-neon-lg">
                 <span className="text-3xl font-bold text-slate-900">
-                  {user?.displayName?.charAt(0).toUpperCase() || user?.email?.charAt(0).toUpperCase() || '?'}
+                  {user?.name?.charAt(0).toUpperCase() || user?.email?.charAt(0).toUpperCase() || '?'}
                 </span>
               </div>
               <div className="absolute -bottom-1 -right-1 w-6 h-6 rounded-full bg-neon-500 flex items-center justify-center shadow-lg">
@@ -110,7 +110,7 @@ export const ProfilePage: React.FC = () => {
             
             <div>
               <h1 className="text-3xl font-bold text-white">
-                {user?.displayName || '사용자'}
+                {user?.name || '사용자'}
               </h1>
               <p className="text-slate-400">{user?.email}</p>
             </div>

--- a/src/pages/wizard/QuestionForm.tsx
+++ b/src/pages/wizard/QuestionForm.tsx
@@ -79,7 +79,7 @@ export const QuestionForm: React.FC<QuestionFormProps> = ({ questions, stepId })
   return (
     <div className="space-y-6">
       {questions.map((question) => {
-        const value = stepData[question.id] || '';
+        const value = (stepData[question.id] as string) || '';
 
         switch (question.type) {
           case 'text':

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -7,63 +7,36 @@
  * - 로그인/로그아웃/회원가입 액션
  * - LocalStorage 연동으로 세션 유지
  * 
+ * API 연동:
+ * - authService를 통해 백엔드 API 호출
+ * 
  * 사용법:
  * const { user, isAuthenticated, login, logout } = useAuthStore();
  */
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import api, { setTokens, clearTokens } from '@/common/axios';
-
-// 사용자 타입
-export interface User {
-  id: string;
-  email: string;
-  displayName?: string;
-  createdAt?: string;
-}
-
-// 인증 응답 타입
-export interface AuthResponse {
-  accessToken: string;
-  refreshToken: string;
-  user: User;
-}
-
-/**
- * API 사용 플래그
- * true로 설정하면 실제 API 호출, false면 Mock 데이터 사용
- */
-const USE_REAL_API = false;
-
-// 회원가입 요청 타입
-interface SignupRequest {
-  email: string;
-  password: string;
-  displayName?: string;
-}
-
-// 로그인 요청 타입
-interface LoginRequest {
-  email: string;
-  password: string;
-}
+import { authService } from '@/service/authService';
+import type { UserInfo } from '@/types';
 
 // Store 상태 타입
 interface AuthState {
   // 상태
-  user: User | null;
+  user: UserInfo | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   error: string | null;
 
   // 액션
-  login: (credentials: LoginRequest) => Promise<void>;
-  signup: (data: SignupRequest) => Promise<void>;
-  logout: () => void;
+  login: (credentials: { email: string; password: string }) => Promise<void>;
+  signup: (data: { email: string; password: string; name: string; company?: string }) => Promise<void>;
+  logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
+  updateProfile: (data: { name?: string; company?: string }) => Promise<void>;
+  changePassword: (data: { currentPassword: string; newPassword: string }) => Promise<void>;
+  deleteAccount: (password: string) => Promise<void>;
   clearError: () => void;
-  setUser: (user: User | null) => void;
+  setUser: (user: UserInfo | null) => void;
 }
 
 /**
@@ -73,6 +46,7 @@ interface AuthState {
  * - 인증 상태를 전역에서 관리
  * - 로그인/로그아웃/회원가입 로직 처리
  * - persist 미들웨어로 새로고침 시에도 상태 유지
+ * - authService를 통해 백엔드 API 연동
  */
 export const useAuthStore = create<AuthState>()(
   persist(
@@ -85,44 +59,17 @@ export const useAuthStore = create<AuthState>()(
 
       /**
        * 로그인
-       * 
        * @param credentials - 이메일, 비밀번호
        */
-      login: async (credentials: LoginRequest) => {
+      login: async (credentials) => {
         set({ isLoading: true, error: null });
 
         try {
-          let userData: User;
-          let accessToken: string;
-          let refreshToken: string;
-
-          if (USE_REAL_API) {
-            // 실제 API 호출
-            const response = await api.post<AuthResponse>('/auth/login', credentials);
-            const authData = response.data;
-            userData = authData.user;
-            accessToken = authData.accessToken;
-            refreshToken = authData.refreshToken;
-          } else {
-            // Mock 응답 (개발용)
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-            
-            userData = {
-              id: 'user_' + Date.now(),
-              email: credentials.email,
-              displayName: credentials.email.split('@')[0],
-              createdAt: new Date().toISOString(),
-            };
-            
-            accessToken = 'mock_access_token_' + Date.now();
-            refreshToken = 'mock_refresh_token_' + Date.now();
-          }
-
-          // 토큰 저장
-          setTokens(accessToken, refreshToken);
+          // 실제 API 호출 (authService가 토큰 저장 처리)
+          const response = await authService.login(credentials);
 
           set({
-            user: userData,
+            user: response.user,
             isAuthenticated: true,
             isLoading: false,
             error: null,
@@ -139,25 +86,16 @@ export const useAuthStore = create<AuthState>()(
 
       /**
        * 회원가입
-       * 
-       * @param data - 이메일, 비밀번호, 이름
+       * @param data - 이메일, 비밀번호, 이름, 회사명(선택)
        */
-      signup: async (signupData: SignupRequest) => {
+      signup: async (signupData) => {
         set({ isLoading: true, error: null });
 
         try {
-          if (USE_REAL_API) {
-            // 실제 API 호출
-            await api.post('/auth/signup', signupData);
-          } else {
-            // Mock 응답 (개발용)
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-          }
-
+          // 실제 API 호출
+          await authService.signup(signupData);
           set({ isLoading: false, error: null });
-          
           // 회원가입 성공 후 자동 로그인은 하지 않음
-          // 사용자가 로그인 페이지에서 직접 로그인하도록 유도
         } catch (error) {
           const message = error instanceof Error ? error.message : '회원가입에 실패했습니다.';
           set({
@@ -171,13 +109,17 @@ export const useAuthStore = create<AuthState>()(
       /**
        * 로그아웃
        */
-      logout: () => {
-        clearTokens();
-        set({
-          user: null,
-          isAuthenticated: false,
-          error: null,
-        });
+      logout: async () => {
+        try {
+          await authService.logout();
+        } finally {
+          // 서버 요청 실패해도 로컬 상태는 초기화
+          set({
+            user: null,
+            isAuthenticated: false,
+            error: null,
+          });
+        }
       },
 
       /**
@@ -185,21 +127,61 @@ export const useAuthStore = create<AuthState>()(
        */
       refreshUser: async () => {
         try {
-          if (USE_REAL_API) {
-            // 실제 API 호출
-            const response = await api.get<User>('/users/me');
-            set({ user: response.data });
-          } else {
-            // Mock: 현재 사용자 정보 유지
-            const currentUser = get().user;
-            if (currentUser) {
-              set({ user: currentUser });
-            }
-          }
+          const userData = await authService.getMe();
+          set({ user: userData });
         } catch (error) {
           // 사용자 정보 조회 실패 시 로그아웃
           console.error('Failed to refresh user:', error);
           get().logout();
+        }
+      },
+
+      /**
+       * 프로필 수정
+       */
+      updateProfile: async (data) => {
+        set({ isLoading: true, error: null });
+        try {
+          const updatedUser = await authService.updateProfile(data);
+          set({ user: updatedUser, isLoading: false });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '프로필 수정에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
+        }
+      },
+
+      /**
+       * 비밀번호 변경
+       */
+      changePassword: async (data) => {
+        set({ isLoading: true, error: null });
+        try {
+          await authService.changePassword(data);
+          set({ isLoading: false });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '비밀번호 변경에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
+        }
+      },
+
+      /**
+       * 계정 삭제
+       */
+      deleteAccount: async (password) => {
+        set({ isLoading: true, error: null });
+        try {
+          await authService.deleteAccount(password);
+          set({
+            user: null,
+            isAuthenticated: false,
+            isLoading: false,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '계정 삭제에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
         }
       },
 
@@ -213,7 +195,7 @@ export const useAuthStore = create<AuthState>()(
       /**
        * 사용자 설정 (테스트/개발용)
        */
-      setUser: (user: User | null) => {
+      setUser: (user) => {
         set({
           user,
           isAuthenticated: !!user,
@@ -232,4 +214,3 @@ export const useAuthStore = create<AuthState>()(
 );
 
 export default useAuthStore;
-

--- a/src/stores/useFinancialStore.ts
+++ b/src/stores/useFinancialStore.ts
@@ -4,36 +4,23 @@
  * 파일 용도:
  * 재무 시뮬레이션 데이터 및 계산을 위한 Zustand Store
  * - 재무 가정 입력 관리
- * - 핵심 재무 지표 자동 계산 (LTV, 손익분기점 등)
+ * - 핵심 재무 지표 계산 (로컬 + API)
  * - 차트 데이터 생성
- * - localStorage에 자동 영속화
  * 
- * 호출 구조:
- * useFinancialStore (이 Store)
- *   ├─> updateInput() - FinancialSimulation에서 입력 값 변경 시 호출
- *   │   ├─> calculateMetrics() - 지표 재계산 트리거
- *   │   └─> generateChartData() - 차트 데이터 재생성 트리거
- *   ├─> calculateMetrics() - 내부 자동 호출
- *   ├─> generateChartData() - 내부 자동 호출
- *   └─> reset() - 기본값으로 초기화
+ * API 연동:
+ * - financialService를 통해 백엔드 API 호출
+ * - preview: 미리보기 (저장 안됨)
+ * - runSimulation: 프로젝트 연동 저장
  * 
  * 사용하는 컴포넌트:
  * - FinancialSimulation: 재무 시뮬레이션 UI (마법사 4단계)
- * 
- * 계산 로직:
- * - Revenue: 고객 수 × 객단가
- * - LTV: 객단가 × 평균 생애 개월 수
- * - LTV/CAC: LTV ÷ CAC (3 이상이 이상적)
- * - Break Even Point: 고정비 ÷ 공헌이익
- * - 12개월 손익 추이: 월 15% 성장률 가정
- * 
- * 영속화:
- * - localStorage 키: 'financial-storage'
+ * - FinancialCalculatorPage: 독립 계산기 페이지
  */
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { FinancialInput, FinancialMetrics, ChartDataPoint } from '@/types';
+import { financialService } from '@/service/financialService';
 
 interface FinancialState {
   /** 사용자 입력 값 */
@@ -42,15 +29,29 @@ interface FinancialState {
   metrics: FinancialMetrics | null;
   /** 차트용 12개월 데이터 */
   chartData: ChartDataPoint[];
+  /** 현재 프로젝트 ID */
+  projectId: string | null;
+  /** 로딩 상태 */
+  isLoading: boolean;
+  /** 에러 메시지 */
+  error: string | null;
   
-  /** 입력 값 업데이트 (자동으로 지표 재계산) */
+  /** 프로젝트 ID 설정 */
+  setProjectId: (projectId: string | null) => void;
+  /** 입력 값 업데이트 (로컬 계산) */
   updateInput: (input: Partial<FinancialInput>) => void;
-  /** 재무 지표 계산 */
+  /** 재무 지표 계산 (로컬) */
   calculateMetrics: () => void;
-  /** 차트 데이터 생성 */
+  /** 차트 데이터 생성 (로컬) */
   generateChartData: () => void;
+  /** 재무 시뮬레이션 실행 (API - 프로젝트 연동) */
+  runSimulation: () => Promise<void>;
+  /** 재무 미리보기 (API - 저장 안됨) */
+  preview: () => Promise<void>;
   /** 기본값으로 리셋 */
   reset: () => void;
+  /** 에러 초기화 */
+  clearError: () => void;
 }
 
 /** 기본 입력 값 */
@@ -70,17 +71,7 @@ const defaultInput: FinancialInput = {
  * - 재무 가정 입력 관리
  * - 핵심 재무 지표 자동 계산
  * - 손익분기점 분석 차트 데이터 생성
- * 
- * 주요 기능:
- * 1. 6가지 재무 가정 입력 (고객 수, 객단가, CAC, 고정비, 변동비율, 이탈률)
- * 2. 실시간 지표 계산 (Revenue, LTV, LTV/CAC, Break Even Point)
- * 3. 12개월 손익 추이 시뮬레이션 (월 15% 성장률 가정)
- * 4. localStorage 자동 영속화
- * 
- * 계산 공식:
- * - LTV = 객단가 × (100 / 이탈률)
- * - LTV/CAC Ratio = LTV ÷ CAC
- * - Break Even Point = 고정비 ÷ (객단가 × (1 - 변동비율/100))
+ * - financialService를 통해 백엔드 API 연동
  */
 export const useFinancialStore = create<FinancialState>()(
   persist(
@@ -88,12 +79,22 @@ export const useFinancialStore = create<FinancialState>()(
       input: defaultInput,
       metrics: null,
       chartData: [],
+      projectId: null,
+      isLoading: false,
+      error: null,
+
+      /**
+       * 프로젝트 ID 설정
+       * @param projectId - 프로젝트 ID (null이면 미리보기 모드)
+       */
+      setProjectId: (projectId: string | null) => {
+        set({ projectId });
+      },
 
       /**
        * 입력 값 업데이트
-       * - 입력이 변경되면 자동으로 지표 재계산 및 차트 재생성
-       * 
-       * @param {Partial<FinancialInput>} newInput - 업데이트할 필드들
+       * - 입력이 변경되면 자동으로 로컬 지표 재계산 및 차트 재생성
+       * @param newInput - 업데이트할 필드들
        */
       updateInput: (newInput: Partial<FinancialInput>) => {
         set((state) => ({
@@ -104,15 +105,8 @@ export const useFinancialStore = create<FinancialState>()(
       },
 
       /**
-       * 재무 지표 계산
-       * 
-       * 계산 항목:
-       * - revenue: 월 매출 = 고객 수 × 객단가
-       * - totalCosts: 총 비용 = 고정비 + 변동비
-       * - profit: 이익 = 매출 - 총 비용
-       * - ltv: 고객 생애가치 = 객단가 × 평균 생애 개월 수
-       * - ltvCacRatio: LTV/CAC 비율
-       * - breakEvenPoint: 손익분기점 고객 수
+       * 재무 지표 계산 (로컬)
+       * 빠른 피드백을 위해 로컬에서 계산
        */
       calculateMetrics: () => {
         const { input } = get();
@@ -129,12 +123,10 @@ export const useFinancialStore = create<FinancialState>()(
         const profit = monthlyRevenue - totalCosts;
 
         // LTV (고객 생애가치) 계산
-        // 평균 생애 개월 수 = 100 / 이탈률 (%)
-        // LTV = 객단가 × 평균 생애 개월 수
         const avgLifetimeMonths = churnRate > 0 ? 100 / churnRate : 20;
         const ltv = pricePerCustomer * avgLifetimeMonths;
 
-        // LTV/CAC 비율 (3 이상이 이상적)
+        // LTV/CAC 비율
         const ltvCacRatio = cac > 0 ? ltv / cac : 0;
 
         // 손익분기점 (고객 수)
@@ -154,10 +146,9 @@ export const useFinancialStore = create<FinancialState>()(
       },
 
       /**
-       * 차트 데이터 생성
+       * 차트 데이터 생성 (로컬)
        * - 12개월간 손익 추이 시뮬레이션
        * - 월 15% 고객 성장률 가정
-       * - 매출, 비용, 이익 추이 계산
        */
       generateChartData: () => {
         const { input } = get();
@@ -185,6 +176,74 @@ export const useFinancialStore = create<FinancialState>()(
       },
 
       /**
+       * 재무 시뮬레이션 실행 (API - 프로젝트 연동)
+       * 결과가 백엔드에 저장됨
+       */
+      runSimulation: async () => {
+        const { projectId, input } = get();
+        if (!projectId) {
+          console.warn('Project ID is not set. Use preview() instead.');
+          return get().preview();
+        }
+
+        set({ isLoading: true, error: null });
+        try {
+          const response = await financialService.runSimulation(projectId, input);
+          
+          // API 응답으로 메트릭스 업데이트
+          set({
+            metrics: {
+              revenue: response.revenue,
+              totalCosts: response.totalCosts,
+              profit: response.profit,
+              ltv: response.ltv,
+              ltvCacRatio: response.ltvCacRatio,
+              breakEvenPoint: response.breakEvenPoint,
+            },
+            chartData: response.monthlyProjections,
+            isLoading: false,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '재무 시뮬레이션에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
+        }
+      },
+
+      /**
+       * 재무 미리보기 (API - 저장 안됨)
+       * 프로젝트 연동 없이 계산만 수행
+       */
+      preview: async () => {
+        const { input } = get();
+        set({ isLoading: true, error: null });
+        
+        try {
+          const response = await financialService.preview(input);
+          
+          // API 응답으로 메트릭스 업데이트
+          set({
+            metrics: {
+              revenue: response.revenue,
+              totalCosts: response.totalCosts,
+              profit: response.profit,
+              ltv: response.ltv,
+              ltvCacRatio: response.ltvCacRatio,
+              breakEvenPoint: response.breakEvenPoint,
+            },
+            chartData: response.monthlyProjections,
+            isLoading: false,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '재무 미리보기에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          // API 실패 시 로컬 계산 결과 사용
+          get().calculateMetrics();
+          get().generateChartData();
+        }
+      },
+
+      /**
        * 기본값으로 리셋
        */
       reset: () => {
@@ -192,12 +251,26 @@ export const useFinancialStore = create<FinancialState>()(
           input: defaultInput,
           metrics: null,
           chartData: [],
+          projectId: null,
+          error: null,
         });
+      },
+
+      /**
+       * 에러 초기화
+       */
+      clearError: () => {
+        set({ error: null });
       },
     }),
     {
       name: 'financial-storage',
+      partialize: (state) => ({
+        input: state.input,
+        projectId: state.projectId,
+      }),
     }
   )
 );
 
+export default useFinancialStore;

--- a/src/stores/useProjectStore.ts
+++ b/src/stores/useProjectStore.ts
@@ -5,45 +5,92 @@
  * 프로젝트 정보 관리를 위한 Zustand Store
  * - 현재 작업 중인 프로젝트 정보 저장
  * - 프로젝트 생성, 수정, 삭제
+ * - 프로젝트 목록 관리
  * - 자동 저장 상태 관리
- * - localStorage에 자동 영속화
  * 
- * 호출 구조:
- * useProjectStore (이 Store)
- *   ├─> createProject() - ProjectCreate 페이지에서 호출
- *   ├─> updateProject() - 프로젝트 정보 수정 시 호출
- *   ├─> setSaveStatus() - useAutoSave hook에서 호출
- *   └─> clearProject() - 프로젝트 초기화
+ * API 연동:
+ * - projectService를 통해 백엔드 API 호출
  * 
  * 사용하는 컴포넌트:
  * - ProjectCreate: 프로젝트 생성
  * - Layout: 프로젝트명 표시
  * - SaveIndicator: 저장 상태 표시
- * 
- * 영속화:
- * - localStorage 키: 'project-storage'
- * - 브라우저 새로고침 시에도 데이터 유지
  */
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { Project, TemplateType, SaveStatus } from '@/types';
+import { SaveStatus } from '@/types';
+import { projectService } from '@/service/projectService';
+import type { ProjectDetailResponse } from '@/types';
+
+// 프로젝트 타입 (백엔드 응답 기반)
+export interface Project {
+  id: string;
+  name: string;
+  templateId: string;
+  description?: string;
+  status?: string;
+  currentStep?: number;
+  isCompleted?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 템플릿 타입
+export interface Template {
+  code: string;
+  name: string;
+  description: string;
+  category: string;
+}
 
 interface ProjectState {
+  /** 프로젝트 목록 */
+  projects: Project[];
   /** 현재 작업 중인 프로젝트 */
   currentProject: Project | null;
+  /** 템플릿 목록 */
+  templates: Template[];
   /** 저장 상태 ('idle' | 'saving' | 'saved' | 'error') */
   saveStatus: SaveStatus;
+  /** 로딩 상태 */
+  isLoading: boolean;
+  /** 에러 메시지 */
+  error: string | null;
   
+  /** 템플릿 목록 조회 */
+  fetchTemplates: (category?: string) => Promise<void>;
+  /** 프로젝트 목록 조회 */
+  fetchProjects: () => Promise<void>;
+  /** 프로젝트 상세 조회 */
+  fetchProject: (projectId: string) => Promise<void>;
   /** 새 프로젝트 생성 */
-  createProject: (name: string, templateId: TemplateType) => void;
-  /** 프로젝트 정보 업데이트 */
+  createProject: (name: string, templateId: string) => Promise<Project>;
+  /** 프로젝트 정보 업데이트 (로컬) */
   updateProject: (updates: Partial<Project>) => void;
+  /** 현재 프로젝트 설정 */
+  setCurrentProject: (project: Project | null) => void;
   /** 저장 상태 설정 */
   setSaveStatus: (status: SaveStatus) => void;
   /** 프로젝트 초기화 */
   clearProject: () => void;
+  /** 에러 초기화 */
+  clearError: () => void;
 }
+
+/**
+ * 백엔드 응답을 프론트엔드 형식으로 변환
+ */
+const convertToProject = (response: ProjectDetailResponse): Project => ({
+  id: response.id,
+  name: response.name,
+  templateId: response.templateId,
+  description: response.description,
+  currentStep: response.currentStep,
+  isCompleted: response.isCompleted,
+  createdAt: response.createdAt,
+  updatedAt: response.updatedAt,
+});
 
 /**
  * useProjectStore
@@ -52,64 +99,137 @@ interface ProjectState {
  * - 프로젝트 생명주기 관리
  * - 프로젝트 메타데이터 저장
  * - 자동 저장 피드백 제공
- * 
- * 주요 기능:
- * 1. 프로젝트 생성 (이름, 템플릿)
- * 2. 프로젝트 정보 업데이트 (자동으로 updatedAt 갱신)
- * 3. 저장 상태 추적
- * 4. localStorage 자동 영속화
+ * - projectService를 통해 백엔드 API 연동
  */
 export const useProjectStore = create<ProjectState>()(
   persist(
     (set) => ({
+      projects: [],
       currentProject: null,
+      templates: [],
       saveStatus: 'idle',
+      isLoading: false,
+      error: null,
 
       /**
-       * 새 프로젝트 생성
-       * - 고유 ID 자동 생성 (타임스탬프 기반)
-       * - 생성/수정 시간 기록
-       * 
-       * @param {string} name - 프로젝트 이름
-       * @param {TemplateType} templateId - 선택한 템플릿 ID
+       * 템플릿 목록 조회
+       * @param category - 템플릿 카테고리 (government, bank, investor)
        */
-      createProject: (name: string, templateId: TemplateType) => {
-        const newProject: Project = {
-          id: `project-${Date.now()}`,
-          name,
-          templateId,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-          currentStep: 1,
-          isCompleted: false,
-        };
-        set({ currentProject: newProject });
+      fetchTemplates: async (category?: string) => {
+        set({ isLoading: true, error: null });
+        try {
+          const response = await projectService.getTemplates(category);
+          set({ 
+            templates: response.templates,
+            isLoading: false,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '템플릿 조회에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
+        }
       },
 
       /**
-       * 프로젝트 정보 업데이트
-       * - 자동으로 updatedAt 갱신
-       * 
-       * @param {Partial<Project>} updates - 업데이트할 필드들
+       * 프로젝트 목록 조회
+       */
+      fetchProjects: async () => {
+        set({ isLoading: true, error: null });
+        try {
+          const response = await projectService.getProjects();
+          const projects = response.data.map(convertToProject);
+          set({ 
+            projects,
+            isLoading: false,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '프로젝트 목록 조회에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
+        }
+      },
+
+      /**
+       * 프로젝트 상세 조회
+       * @param projectId - 프로젝트 ID
+       */
+      fetchProject: async (projectId: string) => {
+        set({ isLoading: true, error: null });
+        try {
+          const response = await projectService.getProject(projectId);
+          const project = convertToProject(response);
+          set({ 
+            currentProject: project,
+            isLoading: false,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '프로젝트 조회에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
+        }
+      },
+
+      /**
+       * 새 프로젝트 생성
+       * @param name - 프로젝트 이름
+       * @param templateId - 템플릿 ID
+       * @returns 생성된 프로젝트
+       */
+      createProject: async (name: string, templateId: string) => {
+        set({ isLoading: true, error: null });
+        try {
+          const response = await projectService.createProject({
+            name,
+            templateId,
+          });
+          const newProject = convertToProject(response);
+          
+          set((state) => ({ 
+            currentProject: newProject,
+            projects: [...state.projects, newProject],
+            isLoading: false,
+          }));
+          
+          return newProject;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '프로젝트 생성에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          throw error;
+        }
+      },
+
+      /**
+       * 프로젝트 정보 업데이트 (로컬 상태)
+       * @param updates - 업데이트할 필드들
        */
       updateProject: (updates: Partial<Project>) => {
         set((state) => {
           if (!state.currentProject) return state;
+          const updatedProject = {
+            ...state.currentProject,
+            ...updates,
+            updatedAt: new Date().toISOString(),
+          };
           return {
-            currentProject: {
-              ...state.currentProject,
-              ...updates,
-              updatedAt: new Date().toISOString(),
-            },
+            currentProject: updatedProject,
+            projects: state.projects.map(p => 
+              p.id === updatedProject.id ? updatedProject : p
+            ),
           };
         });
       },
 
       /**
+       * 현재 프로젝트 설정
+       * @param project - 설정할 프로젝트
+       */
+      setCurrentProject: (project: Project | null) => {
+        set({ currentProject: project });
+      },
+
+      /**
        * 저장 상태 설정
-       * - SaveIndicator 컴포넌트에서 표시
-       * 
-       * @param {SaveStatus} status - 저장 상태
+       * @param status - 저장 상태
        */
       setSaveStatus: (status: SaveStatus) => {
         set({ saveStatus: status });
@@ -117,16 +237,25 @@ export const useProjectStore = create<ProjectState>()(
 
       /**
        * 프로젝트 초기화
-       * - 현재 프로젝트 삭제
-       * - 저장 상태 리셋
        */
       clearProject: () => {
         set({ currentProject: null, saveStatus: 'idle' });
       },
+
+      /**
+       * 에러 초기화
+       */
+      clearError: () => {
+        set({ error: null });
+      },
     }),
     {
       name: 'project-storage',
+      partialize: (state) => ({
+        currentProject: state.currentProject,
+      }),
     }
   )
 );
 
+export default useProjectStore;

--- a/src/stores/useWizardStore.ts
+++ b/src/stores/useWizardStore.ts
@@ -6,39 +6,23 @@
  * - 5단계 마법사의 현재 단계 추적
  * - 각 단계별 질문 답변 저장
  * - 단계 완료 여부 검증
- * - localStorage에 자동 영속화
+ * - 백엔드 API 연동으로 데이터 동기화
  * 
- * 호출 구조:
- * useWizardStore (이 Store)
- *   ├─> setCurrentStep() - WizardStep 페이지에서 호출
- *   ├─> updateStepData() - QuestionForm, FinancialSimulation, PMFSurvey에서 호출
- *   ├─> getStepData() - 각 단계 컴포넌트에서 데이터 로드
- *   ├─> isStepCompleted() - Layout, WizardStep에서 진행률 확인
- *   ├─> goToNextStep() / goToPreviousStep() - 네비게이션
- *   └─> resetWizard() - ProjectCreate에서 새 프로젝트 시작 시 호출
+ * API 연동:
+ * - wizardService를 통해 백엔드 API 호출
  * 
  * 사용하는 컴포넌트:
  * - WizardStep: 단계 관리 및 네비게이션
  * - QuestionForm: 질문 답변 저장
  * - Layout: 진행률 표시
  * - ProjectCreate: 마법사 초기화
- * 
- * 데이터 구조:
- * wizardData: {
- *   1: { question1: 'answer1', question2: 'answer2' },
- *   2: { question3: 'answer3' },
- *   ...
- * }
- * 
- * 영속화:
- * - localStorage 키: 'wizard-storage'
- * - 브라우저 새로고침 시에도 데이터 유지
  */
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { WizardData, WizardStep } from '@/types';
-import { wizardSteps } from '../types/mockData';
+import { wizardService } from '@/service/wizardService';
+import { wizardSteps as defaultWizardSteps } from '../types/mockData';
 
 interface WizardState {
   /** 현재 마법사 단계 (1-5) */
@@ -47,13 +31,27 @@ interface WizardState {
   steps: WizardStep[];
   /** 단계별 사용자 입력 데이터 */
   wizardData: WizardData;
+  /** 현재 프로젝트 ID */
+  projectId: string | null;
+  /** 로딩 상태 */
+  isLoading: boolean;
+  /** 저장 중 상태 */
+  isSaving: boolean;
+  /** 에러 메시지 */
+  error: string | null;
   
+  /** 프로젝트 ID 설정 */
+  setProjectId: (projectId: string) => void;
   /** 현재 단계 설정 */
   setCurrentStep: (step: number) => void;
-  /** 단계별 질문 답변 업데이트 */
-  updateStepData: (stepId: number, questionId: string, value: any) => void;
+  /** 답변 데이터 로드 (API) */
+  loadAnswers: (projectId: string) => Promise<void>;
+  /** 단계별 질문 답변 업데이트 (로컬 + API 저장) */
+  updateStepData: (stepId: number, questionId: string, value: unknown) => void;
+  /** 단계 답변 저장 (API) */
+  saveStepAnswers: (stepId: number) => Promise<void>;
   /** 특정 단계의 데이터 조회 */
-  getStepData: (stepId: number) => Record<string, any>;
+  getStepData: (stepId: number) => Record<string, unknown>;
   /** 단계 완료 여부 확인 (필수 질문 모두 답변 완료) */
   isStepCompleted: (stepId: number) => boolean;
   /** 다음 단계로 이동 */
@@ -62,6 +60,8 @@ interface WizardState {
   goToPreviousStep: () => void;
   /** 마법사 초기화 */
   resetWizard: () => void;
+  /** 에러 초기화 */
+  clearError: () => void;
 }
 
 /**
@@ -71,38 +71,63 @@ interface WizardState {
  * - 5단계 마법사의 상태 관리
  * - 사용자 입력 데이터 저장 및 검증
  * - 진행률 추적
- * 
- * 주요 기능:
- * 1. 단계별 질문 답변 관리
- * 2. 필수 질문 답변 검증
- * 3. 단계 간 네비게이션
- * 4. localStorage 자동 영속화
+ * - wizardService를 통해 백엔드 API 연동
  */
 export const useWizardStore = create<WizardState>()(
   persist(
     (set, get) => ({
       currentStep: 1,
-      steps: wizardSteps,
+      steps: defaultWizardSteps,
       wizardData: {},
+      projectId: null,
+      isLoading: false,
+      isSaving: false,
+      error: null,
+
+      /**
+       * 프로젝트 ID 설정
+       * @param projectId - 프로젝트 ID
+       */
+      setProjectId: (projectId: string) => {
+        set({ projectId });
+      },
 
       /**
        * 현재 단계 설정
-       * 
-       * @param {number} step - 설정할 단계 번호 (1-5)
+       * @param step - 설정할 단계 번호 (1-5)
        */
       setCurrentStep: (step: number) => {
         set({ currentStep: step });
       },
 
       /**
-       * 단계별 질문 답변 업데이트
-       * - 기존 답변이 있으면 덮어쓰기
-       * 
-       * @param {number} stepId - 단계 ID
-       * @param {string} questionId - 질문 ID
-       * @param {any} value - 답변 값
+       * 답변 데이터 로드 (API)
+       * @param projectId - 프로젝트 ID
        */
-      updateStepData: (stepId: number, questionId: string, value: any) => {
+      loadAnswers: async (projectId: string) => {
+        set({ isLoading: true, error: null, projectId });
+        try {
+          const response = await wizardService.getAnswersWithProgress(projectId);
+          set({
+            wizardData: response.answers as WizardData,
+            currentStep: response.completedSteps + 1,
+            isLoading: false,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '답변 데이터 로드에 실패했습니다.';
+          set({ isLoading: false, error: message });
+          // 에러 시에도 기본 상태로 시작
+          set({ wizardData: {}, currentStep: 1 });
+        }
+      },
+
+      /**
+       * 단계별 질문 답변 업데이트 (로컬 상태)
+       * @param stepId - 단계 ID
+       * @param questionId - 질문 ID
+       * @param value - 답변 값
+       */
+      updateStepData: (stepId: number, questionId: string, value: unknown) => {
         set((state) => ({
           wizardData: {
             ...state.wizardData,
@@ -115,10 +140,36 @@ export const useWizardStore = create<WizardState>()(
       },
 
       /**
+       * 단계 답변 저장 (API)
+       * @param stepId - 저장할 단계 ID
+       */
+      saveStepAnswers: async (stepId: number) => {
+        const { projectId, wizardData } = get();
+        if (!projectId) {
+          console.warn('Project ID is not set');
+          return;
+        }
+
+        const stepAnswers = wizardData[stepId] || {};
+        set({ isSaving: true, error: null });
+
+        try {
+          await wizardService.saveStepAnswers(projectId, {
+            stepId,
+            answers: stepAnswers,
+          });
+          set({ isSaving: false });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : '답변 저장에 실패했습니다.';
+          set({ isSaving: false, error: message });
+          throw error;
+        }
+      },
+
+      /**
        * 특정 단계의 데이터 조회
-       * 
-       * @param {number} stepId - 단계 ID
-       * @returns {Record<string, any>} 해당 단계의 답변 객체
+       * @param stepId - 단계 ID
+       * @returns 해당 단계의 답변 객체
        */
       getStepData: (stepId: number) => {
         const state = get();
@@ -127,11 +178,8 @@ export const useWizardStore = create<WizardState>()(
 
       /**
        * 단계 완료 여부 확인
-       * - 모든 필수 질문(required=true)에 답변이 있어야 완료
-       * - 빈 문자열, null, undefined는 미완료로 처리
-       * 
-       * @param {number} stepId - 확인할 단계 ID
-       * @returns {boolean} 완료 여부
+       * @param stepId - 확인할 단계 ID
+       * @returns 완료 여부
        */
       isStepCompleted: (stepId: number) => {
         const state = get();
@@ -151,7 +199,6 @@ export const useWizardStore = create<WizardState>()(
 
       /**
        * 다음 단계로 이동
-       * - 최대 단계를 초과하지 않음
        */
       goToNextStep: () => {
         set((state) => {
@@ -162,7 +209,6 @@ export const useWizardStore = create<WizardState>()(
 
       /**
        * 이전 단계로 이동
-       * - 최소 단계(1) 미만으로 가지 않음
        */
       goToPreviousStep: () => {
         set((state) => {
@@ -173,16 +219,32 @@ export const useWizardStore = create<WizardState>()(
 
       /**
        * 마법사 초기화
-       * - 첫 단계로 돌아가고 모든 데이터 삭제
-       * - 새 프로젝트 시작 시 호출
        */
       resetWizard: () => {
-        set({ currentStep: 1, wizardData: {} });
+        set({ 
+          currentStep: 1, 
+          wizardData: {},
+          projectId: null,
+          error: null,
+        });
+      },
+
+      /**
+       * 에러 초기화
+       */
+      clearError: () => {
+        set({ error: null });
       },
     }),
     {
       name: 'wizard-storage',
+      partialize: (state) => ({
+        currentStep: state.currentStep,
+        wizardData: state.wizardData,
+        projectId: state.projectId,
+      }),
     }
   )
 );
 
+export default useWizardStore;


### PR DESCRIPTION
## 📋 변경 사항

### 1. Store → Service API 연동
각 Store에서 Mock 데이터 대신 실제 API 서비스를 호출하도록 수정:

| Store | Service | 주요 변경 |
|-------|---------|----------|
| `useAuthStore` | `authService` | 로그인/회원가입/로그아웃/프로필 API 연동 |
| `useProjectStore` | `projectService` | 프로젝트 CRUD, 템플릿 목록 조회 API 연동 |
| `useWizardStore` | `wizardService` | 답변 로드/저장 API 연동 |
| `useFinancialStore` | `financialService` | 재무 시뮬레이션/미리보기 API 연동 |

### 2. 컴포넌트 수정
- `ProjectCreate.tsx`: API로 템플릿 목록 조회 및 프로젝트 생성
- `ProfilePage.tsx`, `ProfileEditForm.tsx`: displayName → name 필드 변경
- `SignupPage.tsx`: 회원가입 요청 필드 수정
- `QuestionForm.tsx`: 타입 안전성 개선

### 3. Breaking Changes
- `USE_REAL_API` 플래그 제거 → 항상 실제 API 호출
- `displayName` → `name` 필드명 통일 (백엔드 스펙 맞춤)
- 백엔드 서버 필요 (http://localhost:8080)

---

## ✅ 테스트
- [x] `npm run build` 성공
- [x] TypeScript 타입 에러 없음

## 📝 다음 작업
- [ ] E2E 테스트로 API 연동 검증
- [ ] 에러 핸들링 개선 (네트워크 오류, 인증 만료 등)